### PR TITLE
Refactor Link Account Flow: Rename 'prefillSummary' to 'reviewOnly' a…

### DIFF
--- a/app/client-next-ts/src/components/test-scenario/test-scenario-bundles.ts
+++ b/app/client-next-ts/src/components/test-scenario/test-scenario-bundles.ts
@@ -53,7 +53,7 @@ export type TestScenarioBundleConfig = {
 };
 
 const LINKED_ACCOUNT_OPTIONS: LinkAccountStepOptions = {
-  completionMode: 'prefillSummary',
+  completionMode: 'reviewOnly',
   initialValues: {
     accountType: 'INDIVIDUAL',
     firstName: 'Taylor',
@@ -205,7 +205,7 @@ const BUNDLES: Record<TestScenarioBundleId, TestScenarioBundleConfig> = {
      * @see https://storybook.embedded-finance-dev.com/?path=/story/core-onboardingflow-linked-account-multi-account--existing-accounts-with-add-more
      */
     linkAccountStepOptions: {
-      completionMode: 'prefillSummary',
+      completionMode: 'reviewOnly',
       allowMultipleAccounts: true,
       existingAccountsDisplay: 'compact',
       initialValues: {

--- a/embedded-components/src/core/OnboardingFlow/README.md
+++ b/embedded-components/src/core/OnboardingFlow/README.md
@@ -114,8 +114,8 @@ Pre-populate and configure the **Link bank account** step via `linkAccountStepOp
 
 | Prop | Type | Default | Description |
 | ---- | ---- | ------- | ----------- |
-| `initialValues` | `Partial<BankAccountFormData>` | — | Default form values (partial for `editable`, full for `prefillSummary`). |
-| `completionMode` | `'editable' \| 'prefillSummary'` | — | `editable` = full two-step form; `prefillSummary` = read-only summary + confirm. |
+| `initialValues` | `Partial<BankAccountFormData>` | — | Default form values (partial for `editable`, full for `reviewOnly`). |
+| `completionMode` | `'editable' \| 'reviewOnly'` | `'editable'` | `editable` = full two-step form; `reviewOnly` = read-only summary + confirm. Legacy alias `'prefillSummary'` is also accepted. |
 | `partyId` | `string` | — | Link to an existing party instead of creating one from form fields. |
 | `presetAccounts` | `LinkAccountPresetEntry[]` | — | Multiple preset accounts; renders a dropdown selector. Each entry may have its own `partyId` and `initialValues`. Preset `partyId` takes precedence over top-level `partyId`. |
 | `allowMultipleAccounts` | `boolean` | `false` | After linking, show "Link another account" instead of redirecting to Overview. Existing accounts display as cards above the form on the **link-account** step only. **Overview** shows a short summary (account count + **Manage linked accounts**) so the full list is not duplicated; open the link-account step to add or manage accounts. |
@@ -123,14 +123,14 @@ Pre-populate and configure the **Link bank account** step via `linkAccountStepOp
 | `reviewAcknowledgements` | `LinkAccountReviewAcknowledgement[]` | — | Agreement checkboxes required before submit (both modes). |
 | `showAcknowledgementsIntro` | `boolean` | `false` | Show lead-in text above acknowledgement checkboxes. |
 | `bankFormConfigOverride` | `BankAccountFormConfigOverride` | — | Override linked-account form config (payment methods, field visibility). Deep-partial: `paymentMethods` sub-fields are individually optional. |
-| `summaryDisplayedPaymentTypes` | `RoutingInformationTransactionType[]` | `initialValues.paymentTypes` or `['ACH']` | Payment types shown in prefill summary strip. |
+| `summaryDisplayedPaymentTypes` | `RoutingInformationTransactionType[]` | `initialValues.paymentTypes` or `['ACH']` | Payment types shown in reviewOnly summary strip. |
 
 ## Duplicate account detection
 
 When `allowMultipleAccounts` is enabled and the host supplies `initialValues` whose `accountNumber` already exists among the linked accounts fetched from the API, the link-account step automatically:
 
 1. **Clears** the prefilled values so the user enters fresh data.
-2. **Forces** `completionMode` to `'editable'` regardless of the host-supplied value (overrides `prefillSummary`).
+2. **Forces** `completionMode` to `'editable'` regardless of the host-supplied value (overrides `'reviewOnly'`).
 3. **Validates at schema level** — the form rejects an account-number + routing-number combination that already exists among linked accounts (error key: `fields.accountNumber.validation.duplicate`).
 
 This prevents accidental re-linking of the same account via a stale host-supplied prefill.

--- a/embedded-components/src/core/OnboardingFlow/screens/LinkAccountScreen/LinkAccountPrefillSummaryView.tsx
+++ b/embedded-components/src/core/OnboardingFlow/screens/LinkAccountScreen/LinkAccountPrefillSummaryView.tsx
@@ -1,6 +1,7 @@
-import type { ReactNode } from 'react';
+import { type ReactNode, useMemo } from 'react';
 import { useTranslationWithTokens } from '@/i18n';
 import {
+  AlertTriangleIcon,
   ArrowLeftIcon,
   ArrowRightLeftIcon,
   BanknoteIcon,
@@ -10,17 +11,20 @@ import {
 } from 'lucide-react';
 
 import type { RoutingInformationTransactionType } from '@/api/generated/ep-recipients.schemas';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Separator } from '@/components/ui/separator';
 import { StepLayout } from '@/core/OnboardingFlow/components';
-import type {
-  BankAccountFormConfig,
-  BankAccountFormData,
-  LinkAccountReviewAcknowledgement,
-} from '@/core/RecipientWidgets/components/BankAccountForm/BankAccountForm.types';
+import {
+  createBankAccountFormSchema,
+  type BankAccountFormConfig,
+  type BankAccountFormData,
+  type LinkAccountReviewAcknowledgement,
+} from '@/core/RecipientWidgets/components/BankAccountForm';
+import { useGetBankAccountValidationMessage } from '@/core/RecipientWidgets/components/BankAccountForm/BankAccountForm.schema';
 import { LinkAccountAcknowledgementsGroup } from '@/core/RecipientWidgets/components/BankAccountForm/linkAccountAcknowledgements';
 
 export type LinkAccountPrefillSummaryViewProps = {
@@ -111,14 +115,52 @@ export function LinkAccountPrefillSummaryView({
   const showDefaultCertification =
     !!bankFormConfig.requiredFields.certification;
 
+  // ─── Client-side validation of prefilled data ─────────────────────────────
+  const v = useGetBankAccountValidationMessage();
+  const validationErrors = useMemo(() => {
+    // Validate with certification disabled — the certify checkbox is a separate
+    // UI control, not prefilled data, so its errors should not appear in the alert.
+    const configForValidation: BankAccountFormConfig = {
+      ...bankFormConfig,
+      requiredFields: { ...bankFormConfig.requiredFields, certification: false },
+    };
+    const schema = createBankAccountFormSchema(configForValidation, v);
+    const result = schema.safeParse(data);
+    if (result.success) return [];
+    return result.error.issues.map((issue) => issue.message);
+  }, [data, bankFormConfig, v]);
+
+  const hasValidationErrors = validationErrors.length > 0;
+
   const canSubmit =
-    acknowledgementsComplete && (!showDefaultCertification || certifyChecked);
+    acknowledgementsComplete &&
+    (!showDefaultCertification || certifyChecked) &&
+    !hasValidationErrors;
 
   return (
     <StepLayout title={title} description={description}>
       <div className="eb-mt-6 eb-space-y-6">
         {preSelector}
         {errorAlert}
+
+        {hasValidationErrors ? (
+          <Alert variant="destructive">
+            <AlertTriangleIcon className="eb-h-4 eb-w-4" />
+            <AlertTitle>
+              {tString(
+                'prefillValidation.title',
+                'Invalid prefilled account data'
+              )}
+            </AlertTitle>
+            <AlertDescription>
+              <ul className="eb-mt-1 eb-list-disc eb-pl-4 eb-text-sm">
+                {validationErrors.map((msg) => (
+                  <li key={msg}>{msg}</li>
+                ))}
+              </ul>
+            </AlertDescription>
+          </Alert>
+        ) : null}
 
         <div className="eb-space-y-2">
           <Label className="eb-text-sm eb-font-medium">

--- a/embedded-components/src/core/OnboardingFlow/screens/LinkAccountScreen/LinkAccountPrefillSummaryView.tsx
+++ b/embedded-components/src/core/OnboardingFlow/screens/LinkAccountScreen/LinkAccountPrefillSummaryView.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useMemo } from 'react';
+import { useMemo, type ReactNode } from 'react';
 import { useTranslationWithTokens } from '@/i18n';
 import {
   AlertTriangleIcon,
@@ -122,7 +122,10 @@ export function LinkAccountPrefillSummaryView({
     // UI control, not prefilled data, so its errors should not appear in the alert.
     const configForValidation: BankAccountFormConfig = {
       ...bankFormConfig,
-      requiredFields: { ...bankFormConfig.requiredFields, certification: false },
+      requiredFields: {
+        ...bankFormConfig.requiredFields,
+        certification: false,
+      },
     };
     const schema = createBankAccountFormSchema(configForValidation, v);
     const result = schema.safeParse(data);
@@ -285,7 +288,9 @@ export function LinkAccountPrefillSummaryView({
                 id="eb-link-prefill-certify"
                 className="eb-mt-0.5"
                 checked={certifyChecked}
-                onCheckedChange={(v) => onCertifyCheckedChange(v === true)}
+                onCheckedChange={(checked) =>
+                  onCertifyCheckedChange(checked === true)
+                }
                 disabled={isSubmitting}
               />
               <Label

--- a/embedded-components/src/core/OnboardingFlow/screens/LinkAccountScreen/LinkAccountScreen.test.tsx
+++ b/embedded-components/src/core/OnboardingFlow/screens/LinkAccountScreen/LinkAccountScreen.test.tsx
@@ -243,7 +243,7 @@ describe('LinkAccountScreen', () => {
 
       renderScreen({
         linkAccountStepOptions: {
-          completionMode: 'prefillSummary',
+          completionMode: 'reviewOnly',
           initialValues: FULL_PREFILL_VALUES,
         },
       });
@@ -323,11 +323,11 @@ describe('LinkAccountScreen', () => {
   // Prefill Summary Mode
   // ═══════════════════════════════════════════════════════════════════════════════
 
-  describe('prefillSummary mode', () => {
+  describe('reviewOnly mode', () => {
     test('shows read-only fields with prefilled values', async () => {
       renderScreen({
         linkAccountStepOptions: {
-          completionMode: 'prefillSummary',
+          completionMode: 'reviewOnly',
           initialValues: FULL_PREFILL_VALUES,
         },
       });
@@ -346,7 +346,7 @@ describe('LinkAccountScreen', () => {
 
       renderScreen({
         linkAccountStepOptions: {
-          completionMode: 'prefillSummary',
+          completionMode: 'reviewOnly',
           initialValues: FULL_PREFILL_VALUES,
         },
       });
@@ -370,7 +370,7 @@ describe('LinkAccountScreen', () => {
 
       renderScreen({
         linkAccountStepOptions: {
-          completionMode: 'prefillSummary',
+          completionMode: 'reviewOnly',
           initialValues: FULL_PREFILL_VALUES,
         },
       });
@@ -401,7 +401,7 @@ describe('LinkAccountScreen', () => {
 
       renderScreen({
         linkAccountStepOptions: {
-          completionMode: 'prefillSummary',
+          completionMode: 'reviewOnly',
           initialValues: FULL_PREFILL_VALUES,
           reviewAcknowledgements: [
             {
@@ -462,7 +462,7 @@ describe('LinkAccountScreen', () => {
     test('does NOT show editable form buttons', async () => {
       renderScreen({
         linkAccountStepOptions: {
-          completionMode: 'prefillSummary',
+          completionMode: 'reviewOnly',
           initialValues: FULL_PREFILL_VALUES,
         },
       });
@@ -592,7 +592,7 @@ describe('LinkAccountScreen', () => {
     test('no partyId: useRecipientForm receives undefined', async () => {
       renderScreen({
         linkAccountStepOptions: {
-          completionMode: 'prefillSummary',
+          completionMode: 'reviewOnly',
           initialValues: FULL_PREFILL_VALUES,
         },
       });
@@ -611,7 +611,7 @@ describe('LinkAccountScreen', () => {
     test('top-level partyId passed when no presets exist', async () => {
       renderScreen({
         linkAccountStepOptions: {
-          completionMode: 'prefillSummary',
+          completionMode: 'reviewOnly',
           partyId: 'top-level-only',
           initialValues: FULL_PREFILL_VALUES,
         },
@@ -627,7 +627,7 @@ describe('LinkAccountScreen', () => {
     test('preset partyId takes precedence over top-level', async () => {
       renderScreen({
         linkAccountStepOptions: {
-          completionMode: 'prefillSummary',
+          completionMode: 'reviewOnly',
           partyId: 'top-level-party',
           initialValues: {},
           presetAccounts: [
@@ -651,7 +651,7 @@ describe('LinkAccountScreen', () => {
     test('preset without partyId falls back to top-level', async () => {
       renderScreen({
         linkAccountStepOptions: {
-          completionMode: 'prefillSummary',
+          completionMode: 'reviewOnly',
           partyId: 'top-level-fallback',
           initialValues: {},
           presetAccounts: [
@@ -676,7 +676,7 @@ describe('LinkAccountScreen', () => {
 
       renderScreen({
         linkAccountStepOptions: {
-          completionMode: 'prefillSummary',
+          completionMode: 'reviewOnly',
           partyId: 'party-123',
           initialValues: FULL_PREFILL_VALUES,
         },
@@ -743,7 +743,7 @@ describe('LinkAccountScreen', () => {
     test('does NOT render selector with single preset', async () => {
       renderScreen({
         linkAccountStepOptions: {
-          completionMode: 'prefillSummary',
+          completionMode: 'reviewOnly',
           initialValues: {},
           presetAccounts: [twoPresets[0]],
         },
@@ -776,7 +776,7 @@ describe('LinkAccountScreen', () => {
 
       renderScreen({
         linkAccountStepOptions: {
-          completionMode: 'prefillSummary',
+          completionMode: 'reviewOnly',
           initialValues: {},
           presetAccounts: twoPresets,
         },
@@ -828,7 +828,7 @@ describe('LinkAccountScreen', () => {
 
       renderScreen({
         linkAccountStepOptions: {
-          completionMode: 'prefillSummary',
+          completionMode: 'reviewOnly',
           allowMultipleAccounts: true,
           initialValues: FULL_PREFILL_VALUES,
         },
@@ -854,7 +854,7 @@ describe('LinkAccountScreen', () => {
 
       renderScreen({
         linkAccountStepOptions: {
-          completionMode: 'prefillSummary',
+          completionMode: 'reviewOnly',
           allowMultipleAccounts: true,
           initialValues: {
             ...FULL_PREFILL_VALUES,
@@ -899,7 +899,7 @@ describe('LinkAccountScreen', () => {
 
       renderScreen({
         linkAccountStepOptions: {
-          completionMode: 'prefillSummary',
+          completionMode: 'reviewOnly',
           allowMultipleAccounts: true,
           existingAccountsDisplay: 'compact',
           initialValues: FULL_PREFILL_VALUES,
@@ -917,7 +917,7 @@ describe('LinkAccountScreen', () => {
       renderScreen({
         hideLinkedAccountRemoval: true,
         linkAccountStepOptions: {
-          completionMode: 'prefillSummary',
+          completionMode: 'reviewOnly',
           allowMultipleAccounts: true,
           initialValues: FULL_PREFILL_VALUES,
         },
@@ -934,7 +934,7 @@ describe('LinkAccountScreen', () => {
 
       renderScreen({
         linkAccountStepOptions: {
-          completionMode: 'prefillSummary',
+          completionMode: 'reviewOnly',
           allowMultipleAccounts: true,
           initialValues: FULL_PREFILL_VALUES,
         },
@@ -962,7 +962,7 @@ describe('LinkAccountScreen', () => {
 
       renderScreen({
         linkAccountStepOptions: {
-          completionMode: 'prefillSummary',
+          completionMode: 'reviewOnly',
           allowMultipleAccounts: true,
           // Same account number as ACTIVE_RECIPIENT
           initialValues: {
@@ -975,7 +975,7 @@ describe('LinkAccountScreen', () => {
       // Show "Add account" first
       await user.click(await screen.findByTestId('add-another-account-btn'));
 
-      // Should show editable form (forced by duplicate), NOT prefillSummary
+      // Should show editable form (forced by duplicate), NOT reviewOnly
       await waitFor(() => {
         expect(
           screen.getByRole('button', { name: /Continue to Account Details/i })
@@ -992,7 +992,7 @@ describe('LinkAccountScreen', () => {
 
       renderScreen({
         linkAccountStepOptions: {
-          completionMode: 'prefillSummary',
+          completionMode: 'reviewOnly',
           initialValues: {
             ...FULL_PREFILL_VALUES,
             accountNumber: '12345678901234567',
@@ -1021,7 +1021,7 @@ describe('LinkAccountScreen', () => {
 
       renderScreen({
         linkAccountStepOptions: {
-          completionMode: 'prefillSummary',
+          completionMode: 'reviewOnly',
           initialValues: FULL_PREFILL_VALUES,
         },
       });
@@ -1034,7 +1034,7 @@ describe('LinkAccountScreen', () => {
     test('no error alert when error is null', async () => {
       renderScreen({
         linkAccountStepOptions: {
-          completionMode: 'prefillSummary',
+          completionMode: 'reviewOnly',
           initialValues: FULL_PREFILL_VALUES,
         },
       });
@@ -1057,7 +1057,7 @@ describe('LinkAccountScreen', () => {
 
       renderScreen({
         linkAccountStepOptions: {
-          completionMode: 'prefillSummary',
+          completionMode: 'reviewOnly',
           initialValues: FULL_PREFILL_VALUES,
         },
       });
@@ -1074,7 +1074,7 @@ describe('LinkAccountScreen', () => {
 
       renderScreen({
         linkAccountStepOptions: {
-          completionMode: 'prefillSummary',
+          completionMode: 'reviewOnly',
           initialValues: FULL_PREFILL_VALUES,
         },
       });
@@ -1099,12 +1099,12 @@ describe('LinkAccountScreen', () => {
   // ═══════════════════════════════════════════════════════════════════════════════
 
   describe('unsaved changes tracking', () => {
-    test('prefillSummary marks dirty when acknowledgement is checked', async () => {
+    test('reviewOnly marks dirty when acknowledgement is checked', async () => {
       const user = userEvent.setup();
 
       renderScreen({
         linkAccountStepOptions: {
-          completionMode: 'prefillSummary',
+          completionMode: 'reviewOnly',
           initialValues: FULL_PREFILL_VALUES,
           reviewAcknowledgements: [
             {

--- a/embedded-components/src/core/OnboardingFlow/screens/LinkAccountScreen/LinkAccountScreen.tsx
+++ b/embedded-components/src/core/OnboardingFlow/screens/LinkAccountScreen/LinkAccountScreen.tsx
@@ -170,10 +170,7 @@ export const LinkAccountScreen = () => {
   }, [clientId, acknowledgements.idsKey, prefillSummaryFormData]);
 
   useEffect(() => {
-    if (
-      !prefillSummaryFormData ||
-      effectiveCompletionMode !== 'reviewOnly'
-    ) {
+    if (!prefillSummaryFormData || effectiveCompletionMode !== 'reviewOnly') {
       return undefined;
     }
     const defaultCertShown =

--- a/embedded-components/src/core/OnboardingFlow/screens/LinkAccountScreen/LinkAccountScreen.tsx
+++ b/embedded-components/src/core/OnboardingFlow/screens/LinkAccountScreen/LinkAccountScreen.tsx
@@ -31,8 +31,8 @@ import { LinkAccountPrefillSummaryView } from './LinkAccountPrefillSummaryView';
  * LinkAccountScreen
  *
  * Onboarding step for linking a bank account. Supports three modes:
- * - **`editable`** — `BankAccountForm` two-step wizard.
- * - **`prefillSummary`** — Read-only summary + acknowledgements.
+ * - **`editable`** — `BankAccountForm` two-step wizard. (default)
+ * - **`reviewOnly`** — Read-only summary + acknowledgements.
  * - **Multi-account** — List existing accounts with "Add account" CTA.
  */
 export const LinkAccountScreen = () => {
@@ -82,9 +82,44 @@ export const LinkAccountScreen = () => {
     selectedPresetId,
     setSelectedPresetId,
     effectivePartyId,
-    effectiveInitialValues,
+    effectiveInitialValues: rawEffectiveInitialValues,
     effectiveCompletionMode,
   } = useLinkAccountPreset({ linkAccountStepOptions, existingAccounts });
+
+  // Enrich initial values with party name when partyId resolves to a known party
+  // and the host did not explicitly provide name fields.
+  const effectiveInitialValues = useMemo(() => {
+    if (!effectivePartyId || !clientResponseData?.parties) {
+      return rawEffectiveInitialValues;
+    }
+    const party = (
+      clientResponseData.parties as Array<Record<string, unknown>>
+    ).find((p) => p.id === effectivePartyId);
+    if (!party) return rawEffectiveInitialValues;
+
+    const enriched = { ...rawEffectiveInitialValues };
+
+    if (party.partyType === 'INDIVIDUAL') {
+      const details = party.individualDetails as
+        | { firstName?: string; lastName?: string }
+        | undefined;
+      if (details) {
+        if (!enriched.firstName) enriched.firstName = details.firstName ?? '';
+        if (!enriched.lastName) enriched.lastName = details.lastName ?? '';
+      }
+      if (!enriched.accountType) enriched.accountType = 'INDIVIDUAL';
+    } else if (party.partyType === 'ORGANIZATION') {
+      const details = party.organizationDetails as
+        | { organizationName?: string }
+        | undefined;
+      if (details && !enriched.businessName) {
+        enriched.businessName = details.organizationName ?? '';
+      }
+      if (!enriched.accountType) enriched.accountType = 'ORGANIZATION';
+    }
+
+    return enriched;
+  }, [rawEffectiveInitialValues, effectivePartyId, clientResponseData]);
 
   // ─── Acknowledgements state ─────────────────────────────────────────────────
   const acknowledgementItems = linkAccountStepOptions?.reviewAcknowledgements;
@@ -137,7 +172,7 @@ export const LinkAccountScreen = () => {
   useEffect(() => {
     if (
       !prefillSummaryFormData ||
-      effectiveCompletionMode !== 'prefillSummary'
+      effectiveCompletionMode !== 'reviewOnly'
     ) {
       return undefined;
     }
@@ -263,8 +298,8 @@ export const LinkAccountScreen = () => {
     );
   }
 
-  // ─── Render: Prefill summary mode ──────────────────────────────────────────
-  if (prefillSummaryFormData && effectiveCompletionMode === 'prefillSummary') {
+  // ─── Render: Review-only mode ───────────────────────────────────────────────
+  if (prefillSummaryFormData && effectiveCompletionMode === 'reviewOnly') {
     return (
       <LinkAccountPrefillSummaryView
         title={t('screens.linkAccount.title', 'Link a bank account')}

--- a/embedded-components/src/core/OnboardingFlow/screens/LinkAccountScreen/hooks/useLinkAccountFormConfig.ts
+++ b/embedded-components/src/core/OnboardingFlow/screens/LinkAccountScreen/hooks/useLinkAccountFormConfig.ts
@@ -15,7 +15,7 @@ import {
   type BankAccountFormData,
 } from '@/core/RecipientWidgets/components/BankAccountForm';
 
-/** Fallback base merged with host `initialValues` for `prefillSummary`. */
+/** Fallback base merged with host `initialValues` for `reviewOnly` mode. */
 const LINK_ACCOUNT_PREFILL_MERGE_BASE: BankAccountFormData = {
   accountType: 'INDIVIDUAL',
   firstName: '',
@@ -31,7 +31,7 @@ const LINK_ACCOUNT_PREFILL_MERGE_BASE: BankAccountFormData = {
 
 type UseLinkAccountFormConfigOptions = {
   linkAccountStepOptions: LinkAccountStepOptions | undefined;
-  effectiveCompletionMode: LinkAccountStepCompletionMode | undefined;
+  effectiveCompletionMode: LinkAccountStepCompletionMode;
   effectiveInitialValues: LinkAccountInitialValues;
   acknowledgementItems: readonly LinkAccountReviewAcknowledgement[] | undefined;
 };
@@ -71,7 +71,7 @@ export function useLinkAccountFormConfig({
   }, [configWithOverride, acknowledgementItems]);
 
   const prefillSummaryFormData: BankAccountFormData | null = useMemo(() => {
-    if (effectiveCompletionMode !== 'prefillSummary') return null;
+    if (effectiveCompletionMode !== 'reviewOnly') return null;
     return mergeBankAccountDefaultValues(
       LINK_ACCOUNT_PREFILL_MERGE_BASE,
       effectiveInitialValues
@@ -82,7 +82,7 @@ export function useLinkAccountFormConfig({
     useMemo((): RoutingInformationTransactionType[] => {
       if (
         !prefillSummaryFormData ||
-        effectiveCompletionMode !== 'prefillSummary'
+        effectiveCompletionMode !== 'reviewOnly'
       ) {
         return [];
       }

--- a/embedded-components/src/core/OnboardingFlow/screens/LinkAccountScreen/hooks/useLinkAccountFormConfig.ts
+++ b/embedded-components/src/core/OnboardingFlow/screens/LinkAccountScreen/hooks/useLinkAccountFormConfig.ts
@@ -80,10 +80,7 @@ export function useLinkAccountFormConfig({
 
   const summaryDisplayedPaymentTypes =
     useMemo((): RoutingInformationTransactionType[] => {
-      if (
-        !prefillSummaryFormData ||
-        effectiveCompletionMode !== 'reviewOnly'
-      ) {
+      if (!prefillSummaryFormData || effectiveCompletionMode !== 'reviewOnly') {
         return [];
       }
       const explicit = linkAccountStepOptions?.summaryDisplayedPaymentTypes;

--- a/embedded-components/src/core/OnboardingFlow/screens/LinkAccountScreen/hooks/useLinkAccountPreset.ts
+++ b/embedded-components/src/core/OnboardingFlow/screens/LinkAccountScreen/hooks/useLinkAccountPreset.ts
@@ -8,6 +8,14 @@ import type {
   LinkAccountStepOptions,
 } from '@/core/OnboardingFlow/types/onboarding.types';
 
+/** Normalize legacy `'prefillSummary'` to `'reviewOnly'` and default to `'editable'`. */
+function normalizeCompletionMode(
+  mode: LinkAccountStepCompletionMode | undefined
+): LinkAccountStepCompletionMode {
+  if (mode === 'prefillSummary') return 'reviewOnly';
+  return mode ?? 'editable';
+}
+
 type UseLinkAccountPresetOptions = {
   linkAccountStepOptions: LinkAccountStepOptions | undefined;
   existingAccounts: Recipient[];
@@ -71,8 +79,9 @@ export function useLinkAccountPreset({
     : rawInitialValues;
 
   /** When duplicate detected, fall back to editable mode regardless of host config. */
-  const effectiveCompletionMode: LinkAccountStepCompletionMode | undefined =
-    isDuplicateAccount ? 'editable' : linkAccountStepOptions?.completionMode;
+  const effectiveCompletionMode: LinkAccountStepCompletionMode = isDuplicateAccount
+    ? 'editable'
+    : normalizeCompletionMode(linkAccountStepOptions?.completionMode);
 
   return {
     presetAccounts,

--- a/embedded-components/src/core/OnboardingFlow/screens/LinkAccountScreen/hooks/useLinkAccountPreset.ts
+++ b/embedded-components/src/core/OnboardingFlow/screens/LinkAccountScreen/hooks/useLinkAccountPreset.ts
@@ -79,9 +79,10 @@ export function useLinkAccountPreset({
     : rawInitialValues;
 
   /** When duplicate detected, fall back to editable mode regardless of host config. */
-  const effectiveCompletionMode: LinkAccountStepCompletionMode = isDuplicateAccount
-    ? 'editable'
-    : normalizeCompletionMode(linkAccountStepOptions?.completionMode);
+  const effectiveCompletionMode: LinkAccountStepCompletionMode =
+    isDuplicateAccount
+      ? 'editable'
+      : normalizeCompletionMode(linkAccountStepOptions?.completionMode);
 
   return {
     presetAccounts,

--- a/embedded-components/src/core/OnboardingFlow/stories/Docs.mdx
+++ b/embedded-components/src/core/OnboardingFlow/stories/Docs.mdx
@@ -205,7 +205,7 @@ Linked bank account behavior appears in **two screens** (same API data, same rec
       </td>
       <td>
         <strong>New link:</strong> <code>BankAccountForm</code> or{' '}
-        <code>prefillSummary</code> per <code>linkAccountStepOptions</code>.{' '}
+        <code>reviewOnly</code> per <code>linkAccountStepOptions</code>.{' '}
         <strong>Multi-account:</strong> when{' '}
         <code>allowMultipleAccounts</code> is true, existing accounts display as{' '}
         <code>RecipientCard</code> cards (compact or detailed via{' '}

--- a/embedded-components/src/core/OnboardingFlow/stories/linked-account/OnboardingFlow.LinkedAccount.Interactive.story.tsx
+++ b/embedded-components/src/core/OnboardingFlow/stories/linked-account/OnboardingFlow.LinkedAccount.Interactive.story.tsx
@@ -441,19 +441,19 @@ export const _1_LinkAccount_RecipientStateMachine: Story = {
 };
 
 /**
- * **2. Link account: prefill summary (three acknowledgements)**
+ * **2. Link account: reviewOnly (three acknowledgements)**
  *
- * `completionMode: 'prefillSummary'` with full `initialValues` and three `reviewAcknowledgements` rows.
+ * `completionMode: 'reviewOnly'` with full `initialValues` and three `reviewAcknowledgements` rows.
  * POST /recipients on confirm.
  */
 export const _2_LinkAccount_PrefillSummaryThreeAcknowledgements: Story = {
-  name: '2. Link account: prefill summary (three acknowledgements)',
+  name: '2. Link account: reviewOnly (three acknowledgements)',
   args: {
     ...commonArgs,
     clientId: '0030000132',
     showLinkAccountStep: true,
     linkAccountStepOptions: {
-      completionMode: 'prefillSummary',
+      completionMode: 'reviewOnly',
       initialValues: mockLinkAccountPrefillReadonly,
       summaryDisplayedPaymentTypes: ['ACH'],
       reviewAcknowledgements:

--- a/embedded-components/src/core/OnboardingFlow/stories/linked-account/OnboardingFlow.LinkedAccount.MultiAccount.story.tsx
+++ b/embedded-components/src/core/OnboardingFlow/stories/linked-account/OnboardingFlow.LinkedAccount.MultiAccount.story.tsx
@@ -194,7 +194,7 @@ export const WithPartyId: Story = {
     showLinkAccountStep: true,
     flowEntry: { screenId: 'link-account' },
     linkAccountStepOptions: {
-      completionMode: 'prefillSummary',
+      completionMode: 'reviewOnly',
       partyId: '2000000112',
       initialValues: mockLinkAccountPrefillReadonly,
     },
@@ -247,13 +247,13 @@ export const PresetAccountsEditable: Story = {
 };
 
 /**
- * **3. Preset accounts with selector (prefill summary)**
+ * **3. Preset accounts with selector (reviewOnly)**
  *
- * Same dropdown but in `prefillSummary` mode — user selects a preset, sees the
+ * Same dropdown but in `reviewOnly` mode — user selects a preset, sees the
  * read-only summary, and confirms.
  */
 export const PresetAccountsPrefillSummary: Story = {
-  name: '3. Preset accounts — prefill summary (two accounts)',
+  name: '3. Preset accounts — reviewOnly (two accounts)',
   loaders: [
     async () => {
       resetAndSeedClient(mockClientApproved, DEFAULT_CLIENT_ID);
@@ -284,7 +284,7 @@ export const PresetAccountsPrefillSummary: Story = {
     showLinkAccountStep: true,
     flowEntry: { screenId: 'link-account' },
     linkAccountStepOptions: {
-      completionMode: 'prefillSummary',
+      completionMode: 'reviewOnly',
       initialValues: {},
       presetAccounts: mockPresetAccountsTwo,
     },
@@ -372,7 +372,7 @@ export const AllowMultipleAccounts: Story = {
     clientId: DEFAULT_CLIENT_ID,
     showLinkAccountStep: true,
     linkAccountStepOptions: {
-      completionMode: 'prefillSummary',
+      completionMode: 'reviewOnly',
       allowMultipleAccounts: true,
       initialValues: mockLinkAccountPrefillReadonly,
     },
@@ -407,7 +407,7 @@ export const PresetAccountsWithMultiple: Story = {
     docs: {
       description: {
         story:
-          'Full combination: three preset accounts in a selector, prefill summary mode, and sequential linking enabled. Starts on **Overview** — open **Manage linked accounts**, then after linking one preset the user can pick the next.',
+          'Full combination: three preset accounts in a selector, reviewOnly mode, and sequential linking enabled. Starts on **Overview** — open **Manage linked accounts**, then after linking one preset the user can pick the next.',
       },
     },
   },
@@ -416,7 +416,7 @@ export const PresetAccountsWithMultiple: Story = {
     clientId: DEFAULT_CLIENT_ID,
     showLinkAccountStep: true,
     linkAccountStepOptions: {
-      completionMode: 'prefillSummary',
+      completionMode: 'reviewOnly',
       allowMultipleAccounts: true,
       initialValues: {},
       presetAccounts: mockPresetAccountsThree,
@@ -479,7 +479,7 @@ export const ExistingAccountsWithAddMore: Story = {
     clientId: DEFAULT_CLIENT_ID,
     showLinkAccountStep: true,
     linkAccountStepOptions: {
-      completionMode: 'prefillSummary',
+      completionMode: 'reviewOnly',
       allowMultipleAccounts: true,
       existingAccountsDisplay: 'compact',
       initialValues: mockLinkAccountPrefillReadonly,
@@ -542,7 +542,7 @@ export const ExistingAccountsDetailed: Story = {
     clientId: DEFAULT_CLIENT_ID,
     showLinkAccountStep: true,
     linkAccountStepOptions: {
-      completionMode: 'prefillSummary',
+      completionMode: 'reviewOnly',
       allowMultipleAccounts: true,
       existingAccountsDisplay: 'detailed',
       initialValues: mockLinkAccountPrefillReadonly,

--- a/embedded-components/src/core/OnboardingFlow/stories/linked-account/OnboardingFlow.LinkedAccount.States.story.tsx
+++ b/embedded-components/src/core/OnboardingFlow/stories/linked-account/OnboardingFlow.LinkedAccount.States.story.tsx
@@ -144,14 +144,14 @@ export const ApprovedWithLinkAccountPrefillEditable: Story =
   });
 
 /**
- * **Approved with link account — prefill summary (three default agreements + intro)**
+ * **Approved with link account — reviewOnly (three default agreements + intro)**
  *
  * Disabled ACH strip, holder line, routing/account numbers, lead-in copy, three checkboxes, confirm.
  */
 export const ApprovedWithLinkAccountPrefillSummary: Story =
   buildApprovedClientLinkAccountStory({
     linkAccountStepOptions: {
-      completionMode: 'prefillSummary',
+      completionMode: 'reviewOnly',
       initialValues: mockLinkAccountPrefillReadonly,
       summaryDisplayedPaymentTypes: ['ACH'],
       reviewAcknowledgements:

--- a/embedded-components/src/core/OnboardingFlow/stories/linked-account/README.md
+++ b/embedded-components/src/core/OnboardingFlow/stories/linked-account/README.md
@@ -7,7 +7,7 @@ Storybook: **Core → OnboardingFlow → Linked account**
 | Surface                     | File                                              | Role                                                                                                                          |
 | --------------------------- | ------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
 | **Overview — bank section** | `screens/OverviewScreen/OverviewScreen.tsx`       | Shows linked account **or** “Start” to open the link step. **Verify Account** when `READY_FOR_VALIDATION`.                    |
-| **Link bank account step**  | `screens/LinkAccountScreen/LinkAccountScreen.tsx` | Create flow (`editable` / `prefillSummary`), multi-account management, or redirect to Overview for single existing accounts. |
+| **Link bank account step**  | `screens/LinkAccountScreen/LinkAccountScreen.tsx` | Create flow (`editable` / `reviewOnly`), multi-account management, or redirect to Overview for single existing accounts. |
 
 Both surfaces use the shared **`RecipientCard`** component (from `RecipientWidgets`) for account display — the same component used by **LinkedAccountWidget**. This ensures consistent card rendering, action menus, status alerts, and microdeposit verification across all surfaces.
 

--- a/embedded-components/src/core/OnboardingFlow/stories/linked-account/prefilled/OnboardingFlow.LinkedAccount.Prefilled.story.tsx
+++ b/embedded-components/src/core/OnboardingFlow/stories/linked-account/prefilled/OnboardingFlow.LinkedAccount.Prefilled.story.tsx
@@ -1,0 +1,222 @@
+/**
+ * OnboardingFlow — Linked account (Prefilled Data Validation)
+ *
+ * Demonstrates how the reviewOnly mode handles valid and invalid prefilled data.
+ * When host-provided data fails schema validation, the summary view shows inline
+ * validation errors and blocks submission until the data is corrected.
+ *
+ * ## Stories
+ *
+ * 1. **Valid prefill (reviewOnly)** — All fields pass validation; user can submit.
+ * 2. **Invalid routing (reviewOnly)** — 8-digit routing blocks submission with error.
+ * 3. **Custom description with contact guidance (reviewOnly)** — Content token override
+ *    instructs users to contact the platform if data is incorrect.
+ */
+
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import type { BaseStoryArgs } from '../../../../../../.storybook/preview';
+import type { OnboardingFlowProps } from '../../../types/onboarding.types';
+import {
+  buildApprovedClientLinkAccountStory,
+  commonArgsWithCallbacks,
+  commonArgTypes,
+  mockLinkAccountPrefillInvalidRouting,
+  mockLinkAccountPrefillReadonlyNoName,
+  OnboardingFlowTemplate,
+} from '../../story-utils';
+
+type OnboardingFlowStoryArgs = OnboardingFlowProps & BaseStoryArgs;
+
+const meta: Meta<OnboardingFlowStoryArgs> = {
+  title: 'Core/OnboardingFlow/Linked account/Prefilled',
+  component: OnboardingFlowTemplate,
+  tags: ['@core', '@onboarding', '@linked-accounts', '@prefilled'],
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'Demonstrates how the Onboarding Flow handles valid and invalid prefilled bank account data in `reviewOnly` mode. Invalid data triggers client-side validation errors that block submission.',
+      },
+    },
+  },
+  args: {
+    ...commonArgsWithCallbacks,
+  },
+  argTypes: {
+    ...commonArgTypes,
+  },
+  render: (args) => <OnboardingFlowTemplate {...args} />,
+};
+
+export default meta;
+type Story = StoryObj<OnboardingFlowStoryArgs>;
+
+// ============================================================================
+// Prefill Summary Mode (Non-Editable)
+// ============================================================================
+
+/**
+ * **Valid prefill (reviewOnly)**
+ *
+ * All prefilled fields pass schema validation. The read-only summary renders
+ * without errors and the user can confirm and link immediately.
+ */
+export const ValidPrefillNonEditable: Story = {
+  ...buildApprovedClientLinkAccountStory({
+    linkAccountStepOptions: {
+      completionMode: 'reviewOnly',
+      initialValues: mockLinkAccountPrefillReadonlyNoName,
+      summaryDisplayedPaymentTypes: ['ACH'],
+      partyId: '2000000112',
+    },
+  }),
+  parameters: {
+    ...buildApprovedClientLinkAccountStory({
+      linkAccountStepOptions: {
+        completionMode: 'reviewOnly',
+        initialValues: mockLinkAccountPrefillReadonlyNoName,
+        summaryDisplayedPaymentTypes: ['ACH'],
+        partyId: '2000000112',
+      },
+    }).parameters,
+    docs: {
+      description: {
+        story:
+          'All host-provided data is valid. No validation errors are shown. Submit is enabled immediately (no acknowledgements configured).',
+      },
+    },
+  },
+};
+
+/**
+ * **Invalid routing — contact platform for corrections (non-editable)**
+ *
+ * Host provides an 8-digit routing number (`02100002`) which fails validation.
+ * The custom description (via content token override) instructs the user to
+ * contact their platform provider since the fields are read-only.
+ *
+ * This is the recommended pattern for `reviewOnly` mode: when data is
+ * invalid and the user cannot edit it, provide clear guidance on how to
+ * get the issue resolved.
+ */
+export const InvalidRoutingContactPlatform: Story = {
+  ...buildApprovedClientLinkAccountStory({
+    linkAccountStepOptions: {
+      completionMode: 'reviewOnly',
+      initialValues: mockLinkAccountPrefillInvalidRouting,
+      summaryDisplayedPaymentTypes: ['ACH'],
+      partyId: '2000000112',
+    },
+  }),
+  args: {
+    ...buildApprovedClientLinkAccountStory({
+      linkAccountStepOptions: {
+        completionMode: 'reviewOnly',
+        initialValues: mockLinkAccountPrefillInvalidRouting,
+        summaryDisplayedPaymentTypes: ['ACH'],
+        partyId: '2000000112',
+      },
+    }).args,
+    contentTokensPreset: 'custom',
+    contentTokens: {
+      name: 'enUS',
+      tokens: {
+        'onboarding-overview': {
+          screens: {
+            linkAccount: {
+              prefillSummary: {
+                description:
+                  'Please review the bank account details below. If any information is incorrect or needs to be updated, contact your platform provider for assistance — these fields cannot be edited directly.',
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  parameters: {
+    ...buildApprovedClientLinkAccountStory({
+      linkAccountStepOptions: {
+        completionMode: 'reviewOnly',
+        initialValues: mockLinkAccountPrefillInvalidRouting,
+        summaryDisplayedPaymentTypes: ['ACH'],
+        partyId: '2000000112',
+      },
+    }).parameters,
+    docs: {
+      description: {
+        story:
+          'Combines invalid prefilled data (8-digit routing number) with a content token override that instructs users to contact the platform. Validation error blocks submit while the custom description provides a clear path to resolution.',
+      },
+    },
+  },
+};
+
+// ============================================================================
+// Editable Mode — Same Data, User Can Fix
+// ============================================================================
+
+/**
+ * **Valid prefill (editable)**
+ *
+ * Same valid data as the reviewOnly story, but rendered in `editable` mode.
+ * The user sees a pre-populated form and can modify any field before submitting.
+ */
+export const ValidPrefillEditable: Story = {
+  ...buildApprovedClientLinkAccountStory({
+    linkAccountStepOptions: {
+      completionMode: 'editable',
+      initialValues: mockLinkAccountPrefillReadonlyNoName,
+      partyId: '2000000112',
+    },
+  }),
+  parameters: {
+    ...buildApprovedClientLinkAccountStory({
+      linkAccountStepOptions: {
+        completionMode: 'editable',
+        initialValues: mockLinkAccountPrefillReadonlyNoName,
+        partyId: '2000000112',
+      },
+    }).parameters,
+    docs: {
+      description: {
+        story:
+          'Same valid data as the non-editable variant, but the form is fully editable. User can review, modify, and submit. Validation runs on blur or submit.',
+      },
+    },
+  },
+};
+
+/**
+ * **Invalid routing — 8 digits (editable)**
+ *
+ * Same invalid 8-digit routing number, but in editable mode. No error is shown
+ * on mount — the user sees the pre-populated value and can fix it. Validation
+ * triggers on blur (when the user tabs out of the routing field) or on submit.
+ */
+export const InvalidRoutingEditable: Story = {
+  ...buildApprovedClientLinkAccountStory({
+    linkAccountStepOptions: {
+      completionMode: 'editable',
+      initialValues: mockLinkAccountPrefillInvalidRouting,
+      partyId: '2000000112',
+    },
+  }),
+  parameters: {
+    ...buildApprovedClientLinkAccountStory({
+      linkAccountStepOptions: {
+        completionMode: 'editable',
+        initialValues: mockLinkAccountPrefillInvalidRouting,
+        partyId: '2000000112',
+      },
+    }).parameters,
+    docs: {
+      description: {
+        story:
+          'Same 8-digit routing number (`02100002`) as the non-editable variant, but in editable mode. Error only appears on blur or submit — the user can correct the value inline.',
+      },
+    },
+  },
+};

--- a/embedded-components/src/core/OnboardingFlow/stories/story-utils.tsx
+++ b/embedded-components/src/core/OnboardingFlow/stories/story-utils.tsx
@@ -237,7 +237,7 @@ export const mockLinkAccountPrefillEditable: LinkAccountInitialValues = {
   routingNumbers: [{ paymentType: 'ACH', routingNumber: '021000021' }],
 };
 
-/** Full form-shaped payload for link-account `prefillSummary` (or tests). */
+/** Full form-shaped payload for link-account `reviewOnly` mode (or tests). */
 export const mockLinkAccountPrefillReadonly: BankAccountFormData = {
   accountType: 'INDIVIDUAL',
   firstName: 'Taylor',
@@ -248,10 +248,25 @@ export const mockLinkAccountPrefillReadonly: BankAccountFormData = {
   accountNumber: '44556677889900112',
   bankAccountType: 'CHECKING',
   paymentTypes: ['ACH'],
-  certify: true,
+  certify: false,
 };
 
-/** Default three acknowledgements for `completionMode: 'prefillSummary'` demos. */
+/** Same as {@link mockLinkAccountPrefillReadonly} but without name fields —
+ * when `partyId` is provided, the account holder is derived from the party. */
+export const mockLinkAccountPrefillReadonlyNoName: BankAccountFormData = {
+  accountType: 'INDIVIDUAL',
+  firstName: '',
+  lastName: '',
+  businessName: '',
+  routingNumbers: [{ paymentType: 'ACH', routingNumber: '021000021' }],
+  useSameRoutingNumber: true,
+  accountNumber: '44556677889900112',
+  bankAccountType: 'CHECKING',
+  paymentTypes: ['ACH'],
+  certify: false,
+};
+
+/** Default three acknowledgements for `completionMode: 'reviewOnly'` demos. */
 export const mockLinkAccountPrefillSummaryAcknowledgementsThree: readonly LinkAccountReviewAcknowledgement[] =
   [
     {
@@ -274,6 +289,95 @@ export const mockLinkAccountPrefillSummaryAcknowledgementsThree: readonly LinkAc
       },
     },
   ];
+
+// ============================================================================
+// Linked Account Prefill — Invalid Data Mocks (for validation stories)
+// ============================================================================
+
+/** 8-digit routing number (must be 9 digits).
+ * Name fields omitted — when `partyId` is provided, the account holder comes from the party. */
+export const mockLinkAccountPrefillInvalidRouting: BankAccountFormData = {
+  accountType: 'INDIVIDUAL',
+  firstName: '',
+  lastName: '',
+  businessName: '',
+  routingNumbers: [{ paymentType: 'ACH', routingNumber: '02100002' }], // 8 digits
+  useSameRoutingNumber: true,
+  accountNumber: '44556677889900112',
+  bankAccountType: 'CHECKING',
+  paymentTypes: ['ACH'],
+  certify: false,
+};
+
+/** Missing account number */
+export const mockLinkAccountPrefillMissingAccountNumber: BankAccountFormData = {
+  accountType: 'INDIVIDUAL',
+  firstName: 'Taylor',
+  lastName: 'Morgan',
+  businessName: '',
+  routingNumbers: [{ paymentType: 'ACH', routingNumber: '021000021' }],
+  useSameRoutingNumber: true,
+  accountNumber: '',
+  bankAccountType: 'CHECKING',
+  paymentTypes: ['ACH'],
+  certify: false,
+};
+
+/** Missing account holder name (individual with no first/last) */
+export const mockLinkAccountPrefillMissingName: BankAccountFormData = {
+  accountType: 'INDIVIDUAL',
+  firstName: '',
+  lastName: '',
+  businessName: '',
+  routingNumbers: [{ paymentType: 'ACH', routingNumber: '021000021' }],
+  useSameRoutingNumber: true,
+  accountNumber: '44556677889900112',
+  bankAccountType: 'CHECKING',
+  paymentTypes: ['ACH'],
+  certify: false,
+};
+
+/** Organization with missing business name */
+export const mockLinkAccountPrefillMissingBusinessName: BankAccountFormData = {
+  accountType: 'ORGANIZATION',
+  firstName: '',
+  lastName: '',
+  businessName: '',
+  routingNumbers: [{ paymentType: 'ACH', routingNumber: '021000021' }],
+  useSameRoutingNumber: true,
+  accountNumber: '44556677889900112',
+  bankAccountType: 'CHECKING',
+  paymentTypes: ['ACH'],
+  certify: false,
+};
+
+/** Multiple validation failures: bad routing + missing account number + missing name */
+export const mockLinkAccountPrefillMultipleErrors: BankAccountFormData = {
+  accountType: 'INDIVIDUAL',
+  firstName: '',
+  lastName: '',
+  businessName: '',
+  routingNumbers: [{ paymentType: 'ACH', routingNumber: '1234' }], // 4 digits
+  useSameRoutingNumber: true,
+  accountNumber: '',
+  bankAccountType: 'CHECKING',
+  paymentTypes: ['ACH'],
+  certify: false,
+};
+
+/** Non-numeric routing number (letters in routing) */
+export const mockLinkAccountPrefillNonNumericRouting: BankAccountFormData = {
+  accountType: 'INDIVIDUAL',
+  firstName: 'Taylor',
+  lastName: 'Morgan',
+  businessName: '',
+  routingNumbers: [{ paymentType: 'ACH', routingNumber: '0210ABC21' }],
+  useSameRoutingNumber: true,
+  accountNumber: '44556677889900112',
+  bankAccountType: 'CHECKING',
+  paymentTypes: ['ACH'],
+  certify: false,
+};
 
 // ============================================================================
 // Linked Account Preset Mocks (multi-account / partyId)

--- a/embedded-components/src/core/OnboardingFlow/types/onboarding.types.ts
+++ b/embedded-components/src/core/OnboardingFlow/types/onboarding.types.ts
@@ -49,8 +49,8 @@ export type Jurisdiction = 'US' | 'CA';
 
 /**
  * Host-supplied values for the optional link-account step.
- * With `completionMode: 'editable'`, partial data is allowed and the user completes the two-step form.
- * With `completionMode: 'prefillSummary'`, supply a full {@link BankAccountFormData}-compatible payload;
+ * With `completionMode: 'editable'` (default), partial data is allowed and the user completes the two-step form.
+ * With `completionMode: 'reviewOnly'`, supply a full {@link BankAccountFormData}-compatible payload;
  * the UI shows a read-only summary plus optional `reviewAcknowledgements`.
  * With `completionMode: 'editable'`, the same optional `reviewAcknowledgements` render on step 2 of the bank form.
  */
@@ -82,14 +82,27 @@ export type LinkAccountPresetEntry = {
 };
 
 /**
- * - **`editable`** — Full `BankAccountForm` two-step wizard; optional `initialValues` prefill.
- * - **`prefillSummary`** — Single page via `LinkAccountPrefillSummaryView` (disabled fields + payment strip; shares config/i18n with the form, not the full form tree).
+ * - **`editable`** — Full `BankAccountForm` two-step wizard; optional `initialValues` prefill. **(default)**
+ * - **`reviewOnly`** — Single page via `LinkAccountPrefillSummaryView` (disabled fields + payment strip; shares config/i18n with the form, not the full form tree).
+ *
+ * @deprecated `'prefillSummary'` is accepted as an alias for `'reviewOnly'` for backward compatibility.
  */
-export type LinkAccountStepCompletionMode = 'editable' | 'prefillSummary';
+export type LinkAccountStepCompletionMode =
+  | 'editable'
+  | 'reviewOnly'
+  | 'prefillSummary';
 
 export type LinkAccountStepOptions = {
   initialValues: LinkAccountInitialValues;
-  completionMode: LinkAccountStepCompletionMode;
+  /**
+   * Controls whether the user can edit the prefilled bank account data or only review it.
+   *
+   * - `'editable'` — Interactive form where the user can modify fields before submitting.
+   * - `'reviewOnly'` — Read-only summary; user can only acknowledge and confirm.
+   *
+   * @default 'editable'
+   */
+  completionMode?: LinkAccountStepCompletionMode;
   /**
    * Zero or more agreements before linking (any `completionMode`).
    * Omitted or `[]` = no supplemental checkboxes. When non-empty, every item must be
@@ -97,7 +110,7 @@ export type LinkAccountStepOptions = {
    */
   reviewAcknowledgements?: readonly LinkAccountReviewAcknowledgement[];
   /**
-   * When `completionMode` is `prefillSummary`, payment types listed here appear in the read-only
+   * When `completionMode` is `'reviewOnly'`, payment types listed here appear in the read-only
    * summary strip (labels from `BankAccountForm` config). Defaults to
    * `initialValues.paymentTypes` when set, otherwise `['ACH']`.
    */
@@ -109,7 +122,7 @@ export type LinkAccountStepOptions = {
   showAcknowledgementsIntro?: boolean;
   /**
    * Optional merge on top of {@link useLinkedAccountConfig} for the link-account bank form
-   * (editable step and `prefillSummary` labels). Use to document or trial alternative
+   * (editable step and `reviewOnly` labels). Use to document or trial alternative
    * `paymentMethods.available` / `allowMultiple` sets; production onboarding typically omits this.
    */
   bankFormConfigOverride?: BankAccountFormConfigOverride;


### PR DESCRIPTION
…nd implement client-side validation for prefilled data

- Updated completion mode from 'prefillSummary' to 'reviewOnly' across components and tests.
- Added client-side validation for prefilled data in LinkAccountPrefillSummaryView.
- Enhanced error handling to display validation messages when prefilled data is invalid.
- Adjusted storybook documentation and examples to reflect the new completion mode.
- Created new stories to demonstrate valid and invalid prefilled data handling in reviewOnly mode.