### PR TITLE
refactor(OnboardingFlow): streamline link account integration tests a…

### DIFF
--- a/embedded-components/src/core/OnboardingFlow/OnboardingFlow.scenarioLinkAccount.integration.test.tsx
+++ b/embedded-components/src/core/OnboardingFlow/OnboardingFlow.scenarioLinkAccount.integration.test.tsx
@@ -1,9 +1,8 @@
 /**
  * Integration: OnboardingFlow link-account scenario.
  *
- * Seeds an APPROVED client, navigates to the link-account step, completes
- * the bank account form, verifies the linked account appears on the overview,
- * and exercises the "View Details" dialog.
+ * Seeds an APPROVED client, completes the single-page bank account form on Overview,
+ * verifies the linked account appears, and exercises the "View Details" dialog.
  */
 import { server } from '@/msw/server';
 import { beforeEach, describe, expect, test } from 'vitest';
@@ -40,50 +39,29 @@ describe('OnboardingFlow — link account journey', () => {
       },
     });
 
-    // ─── Overview ─────────────────────────────────────────────────────────────
     await waitForOverview();
 
-    // The bank account section should be visible
     const bankSection = screen
       .getByText(/Link a bank account for payouts/i)
       .closest('[class*="eb-bg-card"]')!;
     expect(bankSection).toBeInTheDocument();
 
-    // Wait for linked recipients query to finish loading (skeleton disappears)
-    await waitFor(() => {
-      expect(
-        within(bankSection as HTMLElement).getByText(/Link an account/i)
-      ).toBeInTheDocument();
-    });
-
-    // Click "Start" to navigate to the link-account screen
-    const startButton = within(bankSection as HTMLElement).getByRole('button', {
-      name: /start/i,
-    });
-    expect(startButton).toBeEnabled();
-    await user.click(startButton);
-
-    // ─── Link Account Screen: Step 1 (Payment Method) ─────────────────────────
+    // Single-page form renders inline (no Continue CTA)
     await waitFor(
       () => {
-        expect(screen.getByText(/Link a bank account/i)).toBeInTheDocument();
+        expect(
+          within(bankSection as HTMLElement).getByLabelText(/Account Number/i)
+        ).toBeInTheDocument();
       },
       { timeout: 10_000 }
     );
 
-    // ACH is pre-selected and locked for linked accounts; just continue
-    const continueButton = screen.getByRole('button', {
-      name: /Continue to Account Details/i,
-    });
-    await user.click(continueButton);
+    expect(
+      within(bankSection as HTMLElement).queryByRole('button', {
+        name: /Continue to Account Details/i,
+      })
+    ).not.toBeInTheDocument();
 
-    // ─── Link Account Screen: Step 2 (Account Details) ────────────────────────
-    // Wait for form fields to appear
-    await waitFor(() => {
-      expect(screen.getByLabelText(/Account Number/i)).toBeInTheDocument();
-    });
-
-    // Select account holder from the individual selector (mock has 2 parties)
     const accountHolderSelect = screen.getByRole('combobox', {
       name: /Account Holder/i,
     });
@@ -93,41 +71,25 @@ describe('OnboardingFlow — link account journey', () => {
     });
     await user.click(peiterOption);
 
-    // Fill account details
     const accountNumberInput = screen.getByLabelText(/Account Number/i);
     await user.clear(accountNumberInput);
     await user.type(accountNumberInput, '12345678901234567');
 
-    // Account type (Checking) is pre-filled via linkAccountStepOptions.initialValues
-
-    // Fill routing number
     const routingInput = screen.getByLabelText(/ACH Routing Number/i);
     await user.clear(routingInput);
     await user.type(routingInput, '021000021');
 
-    // Check the certification checkbox
     const certCheckbox = screen.getByRole('checkbox', {
       name: /I authorize verification/i,
     });
     await user.click(certCheckbox);
 
-    // Submit the form
     const linkButton = screen.getByRole('button', {
       name: /^Link Account$/i,
     });
     expect(linkButton).toBeEnabled();
     await user.click(linkButton);
 
-    // ─── Back to Overview with linked account card ─────────────────────────────
-    // After successful submission, should redirect back to overview
-    await waitFor(
-      () => {
-        expect(screen.getByText(/Overview/i)).toBeInTheDocument();
-      },
-      { timeout: 15_000 }
-    );
-
-    // Success alert should appear (MICRODEPOSITS_INITIATED status)
     await waitFor(() => {
       expect(
         screen.getByText(
@@ -136,27 +98,22 @@ describe('OnboardingFlow — link account journey', () => {
       ).toBeInTheDocument();
     });
 
-    // The account card should display masked account number
     const maskedMatches = screen.getAllByText(/4567/);
     expect(maskedMatches.length).toBeGreaterThan(0);
 
-    // ─── View Details ─────────────────────────────────────────────────────────
     const viewDetailsButton = screen.getByRole('button', {
       name: /View details/i,
     });
     await user.click(viewDetailsButton);
 
-    // Dialog should open with account holder information
     await waitFor(() => {
       const dialog = screen.getByRole('dialog');
       expect(dialog).toBeInTheDocument();
-      // Account number should be shown (masked by default)
       expect(within(dialog).getByText(/4567/)).toBeInTheDocument();
     });
   });
 
-  test('shows "Start" button disabled when client status does not allow linking', async () => {
-    // Re-seed with a status that does NOT allow linking
+  test('shows locked empty state when client status does not allow linking', async () => {
     resetAndSeedClient(
       { ...mockClientApproved, status: 'NEW' as any },
       DEFAULT_CLIENT_ID
@@ -172,17 +129,20 @@ describe('OnboardingFlow — link account journey', () => {
       .getByText(/Link a bank account for payouts/i)
       .closest('[class*="eb-bg-card"]')!;
 
-    // Wait for the link-account card to render (after recipients query loads)
     await waitFor(() => {
       expect(
         within(bankSection as HTMLElement).getByText(/Link an account/i)
       ).toBeInTheDocument();
     });
 
-    const startButton = within(bankSection as HTMLElement).getByRole('button', {
-      name: /start/i,
-    });
-    expect(startButton).toBeDisabled();
+    expect(
+      within(bankSection as HTMLElement).queryByRole('button', {
+        name: /Continue to Account Details/i,
+      })
+    ).not.toBeInTheDocument();
+    expect(
+      within(bankSection as HTMLElement).queryByLabelText(/Account Number/i)
+    ).not.toBeInTheDocument();
   });
 
   test('link account section hidden when showLinkAccountStep is false', async () => {

--- a/embedded-components/src/core/OnboardingFlow/README.md
+++ b/embedded-components/src/core/OnboardingFlow/README.md
@@ -123,18 +123,18 @@ Design reference: **`docs/ptc-feature-plan.md`** (status: implemented). Storyboo
 
 Pre-populate and configure the **Link bank account** step via `linkAccountStepOptions` on `OnboardingFlow`.
 
-| Prop | Type | Default | Description |
-| ---- | ---- | ------- | ----------- |
-| `initialValues` | `Partial<BankAccountFormData>` | — | Default form values (partial for `editable`, full for `reviewOnly`). |
-| `completionMode` | `'editable' \| 'reviewOnly'` | `'editable'` | `editable` = full two-step form; `reviewOnly` = read-only summary + confirm. Legacy alias `'prefillSummary'` is also accepted. |
-| `partyId` | `string` | — | Link to an existing party instead of creating one from form fields. |
-| `presetAccounts` | `LinkAccountPresetEntry[]` | — | Multiple preset accounts; renders a dropdown selector. Each entry may have its own `partyId` and `initialValues`. Preset `partyId` takes precedence over top-level `partyId`. |
-| `allowMultipleAccounts` | `boolean` | `false` | After linking, show "Link another account" instead of redirecting to Overview. Existing accounts display as cards above the form on the **link-account** step only. **Overview** shows a short summary (account count + **Manage linked accounts**) so the full list is not duplicated; open the link-account step to add or manage accounts. |
-| `existingAccountsDisplay` | `'compact' \| 'detailed'` | `'detailed'` | Card style for existing accounts when `allowMultipleAccounts` is true. `detailed` shows status alerts, Verify action, and full action menus (same as LinkedAccountWidget). |
-| `reviewAcknowledgements` | `LinkAccountReviewAcknowledgement[]` | — | Agreement checkboxes required before submit (both modes). |
-| `showAcknowledgementsIntro` | `boolean` | `false` | Show lead-in text above acknowledgement checkboxes. |
-| `bankFormConfigOverride` | `BankAccountFormConfigOverride` | — | Override linked-account form config (payment methods, field visibility). Deep-partial: `paymentMethods` sub-fields are individually optional. |
-| `summaryDisplayedPaymentTypes` | `RoutingInformationTransactionType[]` | `initialValues.paymentTypes` or `['ACH']` | Payment types shown in reviewOnly summary strip. |
+| Prop                           | Type                                  | Default                                   | Description                                                                                                                                                                   |
+| ------------------------------ | ------------------------------------- | ----------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `initialValues`                | `Partial<BankAccountFormData>`        | —                                         | Default form values (partial for `editable`, full for `reviewOnly`).                                                                                                          |
+| `completionMode`               | `'editable' \| 'reviewOnly'`          | `'editable'`                              | `editable` = single-page `BankAccountForm` (party picker + bank details); `reviewOnly` = read-only summary + confirm. Legacy alias `'prefillSummary'` is also accepted.       |
+| `partyId`                      | `string`                              | —                                         | Link to an existing party instead of creating one from form fields.                                                                                                           |
+| `presetAccounts`               | `LinkAccountPresetEntry[]`            | —                                         | Multiple preset accounts; renders a dropdown selector. Each entry may have its own `partyId` and `initialValues`. Preset `partyId` takes precedence over top-level `partyId`. |
+| `allowMultipleAccounts`        | `boolean`                             | `false`                                   | **Overview** shows the linked-account list with **Add account** (opens the link-account step form). After linking, returns to Overview with the updated list.                 |
+| `existingAccountsDisplay`      | `'compact' \| 'detailed'`             | `'detailed'`                              | Card style for existing accounts when `allowMultipleAccounts` is true. `detailed` shows status alerts, Verify action, and full action menus (same as LinkedAccountWidget).    |
+| `reviewAcknowledgements`       | `LinkAccountReviewAcknowledgement[]`  | —                                         | Agreement checkboxes required before submit (both modes).                                                                                                                     |
+| `showAcknowledgementsIntro`    | `boolean`                             | `false`                                   | Show lead-in text above acknowledgement checkboxes.                                                                                                                           |
+| `bankFormConfigOverride`       | `BankAccountFormConfigOverride`       | —                                         | Override linked-account form config (payment methods, field visibility). Deep-partial: `paymentMethods` sub-fields are individually optional.                                 |
+| `summaryDisplayedPaymentTypes` | `RoutingInformationTransactionType[]` | `initialValues.paymentTypes` or `['ACH']` | Payment types shown in reviewOnly summary strip.                                                                                                                              |
 
 ## Duplicate account detection
 
@@ -151,6 +151,7 @@ This prevents accidental re-linking of the same account via a stale host-supplie
 When the form sends `partyId` (either from `linkAccountStepOptions.partyId`, a preset account's `partyId`, or the form's account-holder dropdown), `partyDetails` is omitted from the `POST /recipients` request. The API links the account to the existing party. In MSW mocking, `partyDetails` is resolved from `db.party` so the response populates correctly.
 
 The form tracks the selected party via `selectedPartyId` in the form data, auto-resolved from:
+
 - The organisation party (when `prefillFromClient` is enabled and party type is `ORGANIZATION`)
 - The individual selector dropdown selection (when party type is `INDIVIDUAL`)
 

--- a/embedded-components/src/core/OnboardingFlow/screens/LinkAccountScreen/LinkAccountFormPanel.tsx
+++ b/embedded-components/src/core/OnboardingFlow/screens/LinkAccountScreen/LinkAccountFormPanel.tsx
@@ -1,0 +1,276 @@
+import { useEffect, useMemo, useState, type ReactNode } from 'react';
+import { useTranslationWithTokens } from '@/i18n';
+
+import type { Recipient } from '@/api/generated/ep-recipients.schemas';
+import { useSmbdoGetClient } from '@/api/generated/smbdo';
+import { StepLayout } from '@/core/OnboardingFlow/components';
+import {
+  useFlowContext,
+  useOnboardingContext,
+} from '@/core/OnboardingFlow/contexts';
+import {
+  BankAccountForm,
+  type BankAccountFormData,
+} from '@/core/RecipientWidgets/components/BankAccountForm';
+import { useRecipientForm } from '@/core/RecipientWidgets/hooks/useRecipientForm';
+
+import { LinkAccountErrorAlert } from './components/LinkAccountErrorAlert';
+import { LinkAccountPresetSelector } from './components/LinkAccountPresetSelector';
+import { useLinkAccountAcknowledgements } from './hooks/useLinkAccountAcknowledgements';
+import { useLinkAccountFormConfig } from './hooks/useLinkAccountFormConfig';
+import { useLinkAccountPreset } from './hooks/useLinkAccountPreset';
+import { LinkAccountPrefillSummaryView } from './LinkAccountPrefillSummaryView';
+import { enrichInitialValuesWithPartyName } from './utils/enrichInitialValues';
+
+export type LinkAccountFormPanelProps = {
+  existingAccounts: Recipient[];
+  /** `step` wraps content in StepLayout; `inline` is for Overview embedding. */
+  layout: 'step' | 'inline';
+  onSuccess: () => void;
+  /** When omitted, cancel controls are hidden (typical for Overview inline). */
+  onCancel?: () => void;
+};
+
+/**
+ * Shared create/review UI for linking a bank account — used by
+ * {@link LinkAccountScreen} and Overview's empty bank section.
+ */
+export function LinkAccountFormPanel({
+  existingAccounts,
+  layout,
+  onSuccess,
+  onCancel,
+}: LinkAccountFormPanelProps) {
+  const { t, tString } = useTranslationWithTokens([
+    'onboarding-overview',
+    'common',
+    'linked-accounts',
+  ]);
+  const { setFlowUnsavedChanges } = useFlowContext();
+  const { clientData, linkAccountStepOptions } = useOnboardingContext();
+
+  const clientId = clientData?.id;
+  const [prefillCertifyChecked, setPrefillCertifyChecked] = useState(false);
+
+  const { data: clientResponseData } = useSmbdoGetClient(clientId ?? '', {
+    query: { enabled: !!clientId },
+  });
+
+  const {
+    presetAccounts,
+    selectedPresetId,
+    setSelectedPresetId,
+    effectivePartyId,
+    effectiveInitialValues: rawEffectiveInitialValues,
+    effectiveCompletionMode,
+  } = useLinkAccountPreset({ linkAccountStepOptions, existingAccounts });
+
+  const effectiveInitialValues = useMemo(() => {
+    if (!effectivePartyId || !clientResponseData?.parties) {
+      return rawEffectiveInitialValues;
+    }
+    const party = (
+      clientResponseData.parties as Array<Record<string, unknown>>
+    ).find((p) => p.id === effectivePartyId);
+    if (!party) return rawEffectiveInitialValues;
+
+    return enrichInitialValuesWithPartyName(rawEffectiveInitialValues, party);
+  }, [rawEffectiveInitialValues, effectivePartyId, clientResponseData]);
+
+  const acknowledgementItems = linkAccountStepOptions?.reviewAcknowledgements;
+  const acknowledgements = useLinkAccountAcknowledgements({
+    items: acknowledgementItems,
+    resetDeps: [effectiveCompletionMode],
+  });
+
+  const {
+    configWithOverride,
+    bankFormConfigForPrefill,
+    prefillSummaryFormData,
+    summaryDisplayedPaymentTypes,
+  } = useLinkAccountFormConfig({
+    linkAccountStepOptions,
+    effectiveCompletionMode,
+    effectiveInitialValues,
+    acknowledgementItems,
+  });
+
+  const {
+    submit,
+    status,
+    error: formError,
+    reset,
+  } = useRecipientForm({
+    mode: 'create',
+    recipientType: 'LINKED_ACCOUNT',
+    clientId,
+    partyId: effectivePartyId,
+    onSuccess: () => {
+      reset();
+      onSuccess();
+    },
+  });
+
+  useEffect(() => {
+    setPrefillCertifyChecked(false);
+  }, [clientId, acknowledgements.idsKey, prefillSummaryFormData]);
+
+  useEffect(() => {
+    if (!prefillSummaryFormData || effectiveCompletionMode !== 'reviewOnly') {
+      return undefined;
+    }
+    const defaultCertShown =
+      bankFormConfigForPrefill.requiredFields.certification === true;
+    const dirty =
+      Object.values(acknowledgements.checked).some(Boolean) ||
+      (defaultCertShown && prefillCertifyChecked);
+    setFlowUnsavedChanges('link-account-prefill', dirty);
+    return () => setFlowUnsavedChanges('link-account-prefill', false);
+  }, [
+    acknowledgements.checked,
+    bankFormConfigForPrefill.requiredFields.certification,
+    effectiveCompletionMode,
+    prefillCertifyChecked,
+    prefillSummaryFormData,
+    setFlowUnsavedChanges,
+  ]);
+
+  const config = useMemo(
+    () => ({
+      ...configWithOverride,
+      content: {
+        ...configWithOverride.content,
+        submitButtonText: t('screens.linkAccount.submitButton', 'Link Account'),
+        cancelButtonText: t('common:cancel', 'Cancel'),
+      },
+      existingAccounts: linkAccountStepOptions?.allowMultipleAccounts
+        ? existingAccounts
+        : undefined,
+    }),
+    [
+      configWithOverride,
+      t,
+      linkAccountStepOptions?.allowMultipleAccounts,
+      existingAccounts,
+    ]
+  );
+
+  const handleSubmit = (data: BankAccountFormData) => submit(data);
+  const handleCancel = onCancel
+    ? () => {
+        reset();
+        onCancel();
+      }
+    : undefined;
+
+  const accountSelector =
+    presetAccounts && presetAccounts.length > 1 ? (
+      <LinkAccountPresetSelector
+        presets={presetAccounts}
+        value={selectedPresetId}
+        onChange={setSelectedPresetId}
+      />
+    ) : null;
+
+  const errorAlert = formError ? (
+    <LinkAccountErrorAlert error={formError} />
+  ) : undefined;
+
+  const acknowledgementsIntro =
+    acknowledgementItems?.length &&
+    linkAccountStepOptions?.showAcknowledgementsIntro
+      ? t(
+          'screens.linkAccount.prefillSummary.acknowledgementsIntro',
+          'By electronically linking this account, you agree that:'
+        )
+      : undefined;
+
+  const wrapStep = (
+    content: ReactNode,
+    title: ReactNode,
+    description?: ReactNode
+  ) =>
+    layout === 'step' ? (
+      <StepLayout title={title} description={description}>
+        <div className="eb-mt-6">{content}</div>
+      </StepLayout>
+    ) : (
+      <div className="eb-space-y-4">{content}</div>
+    );
+
+  if (prefillSummaryFormData && effectiveCompletionMode === 'reviewOnly') {
+    return (
+      <LinkAccountPrefillSummaryView
+        wrapInStepLayout={layout === 'step'}
+        title={t('screens.linkAccount.title', 'Link a bank account')}
+        description={t(
+          'screens.linkAccount.prefillSummary.description',
+          'Review your bank details and accept the agreements to link this account.'
+        )}
+        preSelector={accountSelector}
+        data={prefillSummaryFormData}
+        displayedPaymentTypes={summaryDisplayedPaymentTypes}
+        bankFormConfig={bankFormConfigForPrefill}
+        acknowledgements={acknowledgementItems}
+        acknowledgementsIntro={acknowledgementsIntro}
+        acknowledgementChecked={acknowledgements.checked}
+        onAcknowledgementChange={acknowledgements.handleChange}
+        acknowledgementsComplete={acknowledgements.isComplete}
+        certifyChecked={prefillCertifyChecked}
+        onCertifyCheckedChange={setPrefillCertifyChecked}
+        onSubmit={handleSubmit}
+        onCancel={handleCancel}
+        isSubmitting={status === 'pending'}
+        errorAlert={errorAlert}
+        submitLabel={tString(
+          'screens.linkAccount.review.confirmButton',
+          'Confirm and link account'
+        )}
+        cancelLabel={tString('common:cancel', 'Cancel')}
+        groupAriaLabel={tString(
+          'screens.linkAccount.review.acknowledgementsGroupLabel',
+          'Agreements required to link this account'
+        )}
+        accountHolderLabel={tString(
+          'screens.linkAccount.prefillSummary.accountHolderLabel',
+          'Account holder'
+        )}
+      />
+    );
+  }
+
+  const defaultValuesOverride =
+    effectiveCompletionMode === 'editable' ? effectiveInitialValues : undefined;
+
+  return wrapStep(
+    <>
+      {accountSelector}
+      <BankAccountForm
+        config={config}
+        client={clientResponseData ?? clientData}
+        defaultValuesOverride={defaultValuesOverride}
+        onSubmit={handleSubmit}
+        onCancel={handleCancel}
+        isLoading={status === 'pending'}
+        showCard={false}
+        embedded
+        layout="singlePage"
+        alert={errorAlert}
+        onDirtyChange={(dirty) =>
+          setFlowUnsavedChanges('link-account-form', dirty)
+        }
+        reviewAcknowledgements={acknowledgementItems}
+        acknowledgementsIntro={acknowledgementsIntro}
+        reviewAcknowledgementsGroupAriaLabel={tString(
+          'screens.linkAccount.review.acknowledgementsGroupLabel',
+          'Agreements required to link this account'
+        )}
+      />
+    </>,
+    t('screens.linkAccount.title', 'Link a bank account'),
+    t(
+      'screens.linkAccount.description',
+      'Connect your bank account to receive payouts.'
+    )
+  );
+}

--- a/embedded-components/src/core/OnboardingFlow/screens/LinkAccountScreen/LinkAccountPrefillSummaryView.tsx
+++ b/embedded-components/src/core/OnboardingFlow/screens/LinkAccountScreen/LinkAccountPrefillSummaryView.tsx
@@ -30,6 +30,8 @@ import { LinkAccountAcknowledgementsGroup } from '@/core/RecipientWidgets/compon
 export type LinkAccountPrefillSummaryViewProps = {
   title: ReactNode;
   description?: ReactNode;
+  /** When false, content is rendered without StepLayout (Overview inline). Default true. */
+  wrapInStepLayout?: boolean;
   /** Optional pre-selector element (e.g. account preset dropdown) rendered above the summary. */
   preSelector?: ReactNode;
   data: BankAccountFormData;
@@ -48,11 +50,12 @@ export type LinkAccountPrefillSummaryViewProps = {
   certifyChecked: boolean;
   onCertifyCheckedChange: (checked: boolean) => void;
   onSubmit: (payload: BankAccountFormData) => void;
-  onCancel: () => void;
+  /** When omitted, the cancel button is hidden. */
+  onCancel?: () => void;
   isSubmitting: boolean;
   errorAlert?: React.ReactNode;
   submitLabel: string;
-  cancelLabel: string;
+  cancelLabel?: string;
   groupAriaLabel: string;
   /** Label above the read-only account holder line */
   accountHolderLabel: string;
@@ -86,6 +89,7 @@ function achRoutingNumber(data: BankAccountFormData): string {
 export function LinkAccountPrefillSummaryView({
   title,
   description,
+  wrapInStepLayout = true,
   preSelector,
   data,
   displayedPaymentTypes,
@@ -140,194 +144,204 @@ export function LinkAccountPrefillSummaryView({
     (!showDefaultCertification || certifyChecked) &&
     !hasValidationErrors;
 
-  return (
-    <StepLayout title={title} description={description}>
-      <div className="eb-mt-6 eb-space-y-6">
-        {preSelector}
-        {errorAlert}
+  const body = (
+    <div className={wrapInStepLayout ? 'eb-mt-6 eb-space-y-6' : 'eb-space-y-6'}>
+      {preSelector}
+      {errorAlert}
 
-        {hasValidationErrors ? (
-          <Alert variant="destructive">
-            <AlertTriangleIcon className="eb-h-4 eb-w-4" />
-            <AlertTitle>
-              {t('prefillValidation.title', 'Invalid prefilled account data')}
-            </AlertTitle>
-            <AlertDescription>
-              <ul className="eb-mt-1 eb-list-disc eb-pl-4 eb-text-sm">
-                {validationErrors.map((msg) => (
-                  <li key={msg}>{msg}</li>
-                ))}
-              </ul>
+      {hasValidationErrors ? (
+        <Alert variant="destructive">
+          <AlertTriangleIcon className="eb-h-4 eb-w-4" />
+          <AlertTitle>
+            {t('prefillValidation.title', 'Invalid prefilled account data')}
+          </AlertTitle>
+          <AlertDescription>
+            <ul className="eb-mt-1 eb-list-disc eb-pl-4 eb-text-sm">
+              {validationErrors.map((msg) => (
+                <li key={msg}>{msg}</li>
+              ))}
+            </ul>
+          </AlertDescription>
+          {tString('prefillValidation.footnote') && (
+            <AlertDescription className="eb-mt-2 eb-text-xs eb-text-red-800">
+              {t('prefillValidation.footnote')}
             </AlertDescription>
-            {tString('prefillValidation.footnote') && (
-              <AlertDescription className="eb-mt-2 eb-text-xs eb-text-red-800">
-                {t('prefillValidation.footnote')}
-              </AlertDescription>
-            )}
-          </Alert>
-        ) : null}
+          )}
+        </Alert>
+      ) : null}
 
-        <div className="eb-space-y-2">
-          <Label className="eb-text-sm eb-font-medium">
-            {t('paymentMethods.selectAtLeastOne')}
-          </Label>
-          <div className="eb-space-y-3">
-            {displayedPaymentTypes.map((type) => {
-              const cfg = bankFormConfig.paymentMethods.configs[type];
-              const isSelected = selectedTypes.has(type);
-              return (
-                <div key={type} className="eb-flex eb-items-center eb-gap-2">
-                  <div
-                    className={`eb-flex eb-flex-1 eb-items-start eb-gap-3 eb-rounded-lg eb-border eb-p-4 ${
-                      isSelected
-                        ? 'eb-border-primary eb-bg-primary/5'
-                        : 'eb-border-border eb-bg-muted/40 eb-opacity-70'
-                    }`}
-                  >
-                    <div className="eb-pt-0.5 eb-text-primary">
-                      {paymentIcon(type)}
-                    </div>
-                    <div className="eb-flex eb-min-w-0 eb-flex-1 eb-flex-col eb-gap-1">
-                      <span className="eb-font-medium">{cfg?.label}</span>
-                      {isSelected ? (
-                        <span className="eb-inline-flex eb-items-center eb-gap-1 eb-self-start eb-rounded-full eb-bg-informative-accent eb-px-2 eb-py-0.5 eb-text-xs eb-font-medium eb-text-informative">
-                          <LockIcon className="eb-h-3 eb-w-3 eb-shrink-0" />
-                          <span>
-                            {t('paymentMethods.requiredForLinkedAccount')}
-                          </span>
+      <div className="eb-space-y-2">
+        <Label className="eb-text-sm eb-font-medium">
+          {t('paymentMethods.selectAtLeastOne')}
+        </Label>
+        <div className="eb-space-y-3">
+          {displayedPaymentTypes.map((type) => {
+            const cfg = bankFormConfig.paymentMethods.configs[type];
+            const isSelected = selectedTypes.has(type);
+            return (
+              <div key={type} className="eb-flex eb-items-center eb-gap-2">
+                <div
+                  className={`eb-flex eb-flex-1 eb-items-start eb-gap-3 eb-rounded-lg eb-border eb-p-4 ${
+                    isSelected
+                      ? 'eb-border-primary eb-bg-primary/5'
+                      : 'eb-border-border eb-bg-muted/40 eb-opacity-70'
+                  }`}
+                >
+                  <div className="eb-pt-0.5 eb-text-primary">
+                    {paymentIcon(type)}
+                  </div>
+                  <div className="eb-flex eb-min-w-0 eb-flex-1 eb-flex-col eb-gap-1">
+                    <span className="eb-font-medium">{cfg?.label}</span>
+                    {isSelected ? (
+                      <span className="eb-inline-flex eb-items-center eb-gap-1 eb-self-start eb-rounded-full eb-bg-informative-accent eb-px-2 eb-py-0.5 eb-text-xs eb-font-medium eb-text-informative">
+                        <LockIcon className="eb-h-3 eb-w-3 eb-shrink-0" />
+                        <span>
+                          {t('paymentMethods.requiredForLinkedAccount')}
                         </span>
-                      ) : null}
-                    </div>
+                      </span>
+                    ) : null}
                   </div>
                 </div>
-              );
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      <div className="eb-space-y-2">
+        <Label
+          htmlFor="eb-prefill-account-holder"
+          className="eb-text-sm eb-font-medium"
+        >
+          {accountHolderLabel}
+        </Label>
+        <Input
+          id="eb-prefill-account-holder"
+          value={accountHolderName || '—'}
+          readOnly
+          disabled
+          className="eb-bg-muted/50"
+          aria-readonly
+        />
+      </div>
+
+      <div className="eb-grid eb-grid-cols-1 eb-gap-4 md:eb-grid-cols-2">
+        <div className="eb-space-y-2">
+          <Label htmlFor="eb-prefill-routing">
+            {t('routingNumbers.singleMethodLabel', {
+              method: tString('paymentMethods.ACH.shortLabel'),
             })}
-          </div>
-        </div>
-
-        <div className="eb-space-y-2">
-          <Label
-            htmlFor="eb-prefill-account-holder"
-            className="eb-text-sm eb-font-medium"
-          >
-            {accountHolderLabel}
           </Label>
           <Input
-            id="eb-prefill-account-holder"
-            value={accountHolderName || '—'}
+            id="eb-prefill-routing"
+            value={routing}
             readOnly
             disabled
             className="eb-bg-muted/50"
             aria-readonly
           />
         </div>
-
-        <div className="eb-grid eb-grid-cols-1 eb-gap-4 md:eb-grid-cols-2">
-          <div className="eb-space-y-2">
-            <Label htmlFor="eb-prefill-routing">
-              {t('routingNumbers.singleMethodLabel', {
-                method: tString('paymentMethods.ACH.shortLabel'),
-              })}
-            </Label>
-            <Input
-              id="eb-prefill-routing"
-              value={routing}
-              readOnly
-              disabled
-              className="eb-bg-muted/50"
-              aria-readonly
-            />
-          </div>
-          <div className="eb-space-y-2">
-            <Label htmlFor="eb-prefill-account">
-              {t('fields.accountNumber.label')}
-            </Label>
-            <Input
-              id="eb-prefill-account"
-              value={data.accountNumber ?? ''}
-              readOnly
-              disabled
-              className="eb-bg-muted/50"
-              aria-readonly
-            />
-          </div>
-        </div>
-
         <div className="eb-space-y-2">
-          <Label htmlFor="eb-prefill-bank-type">
-            {t('fields.accountType.label')}
+          <Label htmlFor="eb-prefill-account">
+            {t('fields.accountNumber.label')}
           </Label>
           <Input
-            id="eb-prefill-bank-type"
-            value={
-              data.bankAccountType === 'SAVINGS'
-                ? tString('accountTypes.savings')
-                : tString('accountTypes.checking')
-            }
+            id="eb-prefill-account"
+            value={data.accountNumber ?? ''}
             readOnly
             disabled
             className="eb-bg-muted/50"
             aria-readonly
           />
         </div>
+      </div>
 
-        {acknowledgements?.length ? (
-          <LinkAccountAcknowledgementsGroup
-            items={acknowledgements}
-            checked={acknowledgementChecked}
-            onCheckedChange={onAcknowledgementChange}
-            disabled={isSubmitting}
-            groupAriaLabel={groupAriaLabel}
-            intro={acknowledgementsIntro}
-          />
-        ) : null}
+      <div className="eb-space-y-2">
+        <Label htmlFor="eb-prefill-bank-type">
+          {t('fields.accountType.label')}
+        </Label>
+        <Input
+          id="eb-prefill-bank-type"
+          value={
+            data.bankAccountType === 'SAVINGS'
+              ? tString('accountTypes.savings')
+              : tString('accountTypes.checking')
+          }
+          readOnly
+          disabled
+          className="eb-bg-muted/50"
+          aria-readonly
+        />
+      </div>
 
-        {showDefaultCertification ? (
-          <>
-            <Separator />
-            <div className="eb-flex eb-items-start eb-space-x-2">
-              <Checkbox
-                id="eb-link-prefill-certify"
-                className="eb-mt-0.5"
-                checked={certifyChecked}
-                onCheckedChange={(checked) =>
-                  onCertifyCheckedChange(checked === true)
-                }
-                disabled={isSubmitting}
-              />
-              <Label
-                htmlFor="eb-link-prefill-certify"
-                className="eb-cursor-pointer eb-text-sm eb-font-normal eb-text-foreground peer-disabled:eb-cursor-not-allowed peer-disabled:eb-opacity-70"
-              >
-                {bankFormConfig.content.certificationText}
-              </Label>
-            </div>
-          </>
-        ) : null}
+      {acknowledgements?.length ? (
+        <LinkAccountAcknowledgementsGroup
+          items={acknowledgements}
+          checked={acknowledgementChecked}
+          onCheckedChange={onAcknowledgementChange}
+          disabled={isSubmitting}
+          groupAriaLabel={groupAriaLabel}
+          intro={acknowledgementsIntro}
+        />
+      ) : null}
 
-        <div className="eb-flex eb-flex-wrap eb-gap-2">
-          <Button
-            type="button"
-            className="eb-inline-flex eb-items-center eb-gap-2"
-            disabled={isSubmitting || !canSubmit}
-            onClick={() =>
-              onSubmit({
-                ...data,
-                certify: showDefaultCertification ? certifyChecked : true,
-              })
-            }
-          >
-            {isSubmitting ? (
-              <Loader2Icon className="eb-size-4 eb-animate-spin" aria-hidden />
-            ) : null}
-            {submitLabel}
-          </Button>
+      {showDefaultCertification ? (
+        <>
+          <Separator />
+          <div className="eb-flex eb-items-start eb-space-x-2">
+            <Checkbox
+              id="eb-link-prefill-certify"
+              className="eb-mt-0.5"
+              checked={certifyChecked}
+              onCheckedChange={(checked) =>
+                onCertifyCheckedChange(checked === true)
+              }
+              disabled={isSubmitting}
+            />
+            <Label
+              htmlFor="eb-link-prefill-certify"
+              className="peer-disabled:eb-cursor-not-allowed peer-disabled:eb-opacity-70 eb-cursor-pointer eb-text-sm eb-font-normal eb-text-foreground"
+            >
+              {bankFormConfig.content.certificationText}
+            </Label>
+          </div>
+        </>
+      ) : null}
+
+      <div className="eb-flex eb-flex-wrap eb-gap-2">
+        <Button
+          type="button"
+          className="eb-inline-flex eb-items-center eb-gap-2"
+          disabled={isSubmitting || !canSubmit}
+          onClick={() =>
+            onSubmit({
+              ...data,
+              certify: showDefaultCertification ? certifyChecked : true,
+            })
+          }
+        >
+          {isSubmitting ? (
+            <Loader2Icon className="eb-size-4 eb-animate-spin" aria-hidden />
+          ) : null}
+          {submitLabel}
+        </Button>
+        {onCancel ? (
           <Button variant="outline" size="sm" type="button" onClick={onCancel}>
             <ArrowLeftIcon className="eb-size-4" />
             {cancelLabel}
           </Button>
-        </div>
+        ) : null}
       </div>
+    </div>
+  );
+
+  if (!wrapInStepLayout) {
+    return body;
+  }
+
+  return (
+    <StepLayout title={title} description={description}>
+      {body}
     </StepLayout>
   );
 }

--- a/embedded-components/src/core/OnboardingFlow/screens/LinkAccountScreen/LinkAccountScreen.test.tsx
+++ b/embedded-components/src/core/OnboardingFlow/screens/LinkAccountScreen/LinkAccountScreen.test.tsx
@@ -141,13 +141,6 @@ const ACTIVE_RECIPIENT = {
   createdAt: '2024-01-15T10:30:00Z',
 };
 
-const SECOND_RECIPIENT = {
-  ...ACTIVE_RECIPIENT,
-  id: 'la-existing-2',
-  partyDetails: { type: 'ORGANIZATION' as const, businessName: 'Acme Corp' },
-  account: { ...ACTIVE_RECIPIENT.account, number: '98765432109876543' },
-};
-
 function mockRecipientsResponse(recipients: unknown[] = []) {
   vi.mocked(useGetAllRecipients).mockReturnValue({
     data: { recipients },
@@ -295,7 +288,7 @@ describe('LinkAccountScreen', () => {
 
       expect(
         await screen.findByRole('button', {
-          name: /Continue to Account Details/i,
+          name: /^Link Account$/i,
         })
       ).toBeInTheDocument();
       expect(mockGoTo).not.toHaveBeenCalled();
@@ -313,7 +306,7 @@ describe('LinkAccountScreen', () => {
 
       expect(
         await screen.findByRole('button', {
-          name: /Continue to Account Details/i,
+          name: /^Link Account$/i,
         })
       ).toBeInTheDocument();
       expect(mockGoTo).not.toHaveBeenCalled();
@@ -486,9 +479,7 @@ describe('LinkAccountScreen', () => {
   // ═══════════════════════════════════════════════════════════════════════════════
 
   describe('editable mode', () => {
-    test('renders BankAccountForm step 1 with prefilled values', async () => {
-      const user = userEvent.setup();
-
+    test('renders single-page BankAccountForm with prefilled values', async () => {
       renderScreen({
         linkAccountStepOptions: {
           completionMode: 'editable',
@@ -505,17 +496,15 @@ describe('LinkAccountScreen', () => {
         await screen.findByRole('heading', { name: /Link a bank account/i })
       ).toBeInTheDocument();
 
-      // Step 1 button visible
-      await user.click(
-        screen.getByRole('button', { name: /Continue to Account Details/i })
-      );
+      expect(
+        screen.queryByRole('button', { name: /Continue to Account Details/i })
+      ).not.toBeInTheDocument();
 
-      // Prefilled account number on step 2
       const accountInput = await screen.findByLabelText(/account number/i);
       expect(accountInput).toHaveValue('98765432109876543');
     });
 
-    test('with reviewAcknowledgements: shows intro text and gates submit on step 2', async () => {
+    test('with reviewAcknowledgements: shows intro text and gates submit', async () => {
       const user = userEvent.setup();
 
       renderScreen({
@@ -543,13 +532,6 @@ describe('LinkAccountScreen', () => {
         },
       });
 
-      await user.click(
-        await screen.findByRole('button', {
-          name: /Continue to Account Details/i,
-        })
-      );
-
-      // Intro text
       expect(
         await screen.findByText(/By electronically linking this account/i)
       ).toBeInTheDocument();
@@ -557,7 +539,6 @@ describe('LinkAccountScreen', () => {
       const submitBtn = screen.getByRole('button', { name: /^Link Account$/i });
       await waitFor(() => expect(submitBtn).toBeDisabled());
 
-      // Check first acknowledgement — still gated
       await user.click(
         screen.getByRole('checkbox', {
           name: /primarily for business purposes/i,
@@ -565,7 +546,6 @@ describe('LinkAccountScreen', () => {
       );
       expect(submitBtn).toBeDisabled();
 
-      // Check second — now enabled
       await user.click(
         screen.getByRole('checkbox', {
           name: /authorize verification of this linked account/i,
@@ -579,9 +559,12 @@ describe('LinkAccountScreen', () => {
 
       expect(
         await screen.findByRole('button', {
-          name: /Continue to Account Details/i,
+          name: /^Link Account$/i,
         })
       ).toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: /Continue to Account Details/i })
+      ).not.toBeInTheDocument();
     });
   });
 
@@ -824,33 +807,7 @@ describe('LinkAccountScreen', () => {
       expect(mockGoTo).not.toHaveBeenCalled();
     });
 
-    test('shows existing accounts list and "Add account" button, hides form', async () => {
-      mockRecipientsResponse([ACTIVE_RECIPIENT]);
-
-      renderScreen({
-        linkAccountStepOptions: {
-          completionMode: 'reviewOnly',
-          allowMultipleAccounts: true,
-          initialValues: FULL_PREFILL_VALUES,
-        },
-      });
-
-      expect(
-        await screen.findByTestId('existing-linked-accounts')
-      ).toBeInTheDocument();
-      expect(screen.getByTestId('add-another-account-btn')).toBeInTheDocument();
-
-      // Form not visible
-      expect(
-        screen.queryByRole('button', { name: /Confirm and link account/i })
-      ).not.toBeInTheDocument();
-      expect(
-        screen.queryByRole('button', { name: /Continue to Account Details/i })
-      ).not.toBeInTheDocument();
-    });
-
-    test('clicking "Add account" reveals form and hides existing accounts section', async () => {
-      const user = userEvent.setup();
+    test('shows form immediately when existing accounts are present', async () => {
       mockRecipientsResponse([ACTIVE_RECIPIENT]);
 
       renderScreen({
@@ -859,78 +816,22 @@ describe('LinkAccountScreen', () => {
           allowMultipleAccounts: true,
           initialValues: {
             ...FULL_PREFILL_VALUES,
-            accountNumber: '99988877766655544', // Different from existing
+            accountNumber: '99988877766655544',
           },
         },
       });
 
-      await user.click(await screen.findByTestId('add-another-account-btn'));
-
-      // Form now visible
-      await waitFor(() => {
-        expect(
-          screen.getByRole('button', { name: /Confirm and link account/i })
-        ).toBeInTheDocument();
-      });
-
-      // Existing section hidden after form shown
+      expect(
+        await screen.findByRole('button', {
+          name: /Confirm and link account/i,
+        })
+      ).toBeInTheDocument();
       expect(
         screen.queryByTestId('existing-linked-accounts')
       ).not.toBeInTheDocument();
     });
 
-    test('displays count for multiple existing accounts', async () => {
-      mockRecipientsResponse([ACTIVE_RECIPIENT, SECOND_RECIPIENT]);
-
-      renderScreen({
-        linkAccountStepOptions: {
-          completionMode: 'editable',
-          allowMultipleAccounts: true,
-          initialValues: {},
-        },
-      });
-
-      expect(
-        await screen.findByText(/Linked accounts \(2\)/i)
-      ).toBeInTheDocument();
-    });
-
-    test('existingAccountsDisplay: compact renders existing section', async () => {
-      mockRecipientsResponse([ACTIVE_RECIPIENT]);
-
-      renderScreen({
-        linkAccountStepOptions: {
-          completionMode: 'reviewOnly',
-          allowMultipleAccounts: true,
-          existingAccountsDisplay: 'compact',
-          initialValues: FULL_PREFILL_VALUES,
-        },
-      });
-
-      expect(
-        await screen.findByTestId('existing-linked-accounts')
-      ).toBeInTheDocument();
-    });
-
-    test('hideLinkedAccountRemoval renders without remove actions', async () => {
-      mockRecipientsResponse([ACTIVE_RECIPIENT]);
-
-      renderScreen({
-        hideLinkedAccountRemoval: true,
-        linkAccountStepOptions: {
-          completionMode: 'reviewOnly',
-          allowMultipleAccounts: true,
-          initialValues: FULL_PREFILL_VALUES,
-        },
-      });
-
-      expect(
-        await screen.findByTestId('existing-linked-accounts')
-      ).toBeInTheDocument();
-      expect(screen.getByTestId('add-another-account-btn')).toBeInTheDocument();
-    });
-
-    test('onSuccess resets form state and does NOT navigate away', async () => {
+    test('onSuccess navigates to overview with success session flag', async () => {
       const triggerSuccess = mockRecipientFormWithCallback();
 
       renderScreen({
@@ -947,9 +848,12 @@ describe('LinkAccountScreen', () => {
         triggerSuccess();
       });
 
-      // Does not navigate to overview
-      expect(mockGoTo).not.toHaveBeenCalled();
-      // Resets form
+      expect(mockUpdateSessionData).toHaveBeenCalledWith({
+        linkAccountJustCreated: true,
+      });
+      expect(mockGoTo).toHaveBeenCalledWith('overview', {
+        resetHistory: true,
+      });
       expect(mockReset).toHaveBeenCalled();
     });
   });
@@ -960,7 +864,6 @@ describe('LinkAccountScreen', () => {
 
   describe('duplicate account detection', () => {
     test('forces editable mode when prefilled account already exists', async () => {
-      const user = userEvent.setup();
       mockRecipientsResponse([ACTIVE_RECIPIENT]);
 
       renderScreen({
@@ -975,17 +878,17 @@ describe('LinkAccountScreen', () => {
         },
       });
 
-      // Show "Add account" first
-      await user.click(await screen.findByTestId('add-another-account-btn'));
-
-      // Should show editable form (forced by duplicate), NOT reviewOnly
+      // Should show editable single-page form (forced by duplicate), NOT reviewOnly
       await waitFor(() => {
         expect(
-          screen.getByRole('button', { name: /Continue to Account Details/i })
+          screen.getByRole('button', { name: /^Link Account$/i })
         ).toBeInTheDocument();
       });
       expect(
         screen.queryByRole('button', { name: /Confirm and link account/i })
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: /Continue to Account Details/i })
       ).not.toBeInTheDocument();
     });
 

--- a/embedded-components/src/core/OnboardingFlow/screens/LinkAccountScreen/LinkAccountScreen.tsx
+++ b/embedded-components/src/core/OnboardingFlow/screens/LinkAccountScreen/LinkAccountScreen.tsx
@@ -1,61 +1,34 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import { useTranslationWithTokens } from '@/i18n';
-import { useQueryClient } from '@tanstack/react-query';
 
 import { useGetAllRecipients } from '@/api/generated/ep-recipients';
 import type { Recipient } from '@/api/generated/ep-recipients.schemas';
-import { useSmbdoGetClient } from '@/api/generated/smbdo';
 import { Skeleton } from '@/components/ui/skeleton';
 import { StepLayout } from '@/core/OnboardingFlow/components';
 import {
   useFlowContext,
   useOnboardingContext,
 } from '@/core/OnboardingFlow/contexts';
-import {
-  BankAccountForm,
-  type BankAccountFormData,
-} from '@/core/RecipientWidgets/components/BankAccountForm';
-import { useRecipientForm } from '@/core/RecipientWidgets/hooks/useRecipientForm';
-import { invalidateRecipientQueries } from '@/core/RecipientWidgets/utils/invalidateRecipientQueries';
 
-import { ExistingLinkedAccountsList } from './components/ExistingLinkedAccountsList';
-import { LinkAccountErrorAlert } from './components/LinkAccountErrorAlert';
-import { LinkAccountPresetSelector } from './components/LinkAccountPresetSelector';
-import { useLinkAccountAcknowledgements } from './hooks/useLinkAccountAcknowledgements';
-import { useLinkAccountFormConfig } from './hooks/useLinkAccountFormConfig';
-import { useLinkAccountPreset } from './hooks/useLinkAccountPreset';
-import { LinkAccountPrefillSummaryView } from './LinkAccountPrefillSummaryView';
-import { enrichInitialValuesWithPartyName } from './utils/enrichInitialValues';
+import { LinkAccountFormPanel } from './LinkAccountFormPanel';
 
 /**
  * LinkAccountScreen
  *
- * Onboarding step for linking a bank account. Supports three modes:
- * - **`editable`** — `BankAccountForm` two-step wizard. (default)
- * - **`reviewOnly`** — Read-only summary + acknowledgements.
- * - **Multi-account** — List existing accounts with "Add account" CTA.
+ * Dedicated onboarding step for linking a bank account (sidebar / Add flow).
+ * Empty Overview embeds the same form via {@link LinkAccountFormPanel}.
+ * Supports `editable` and `reviewOnly` completion modes.
  */
 export const LinkAccountScreen = () => {
-  const { t, tString } = useTranslationWithTokens([
+  const { t } = useTranslationWithTokens([
     'onboarding-overview',
     'common',
     'linked-accounts',
   ]);
-  const { goTo, setFlowUnsavedChanges, updateSessionData } = useFlowContext();
-  const { clientData, linkAccountStepOptions, hideLinkedAccountRemoval } =
-    useOnboardingContext();
-  const queryClient = useQueryClient();
+  const { goTo, updateSessionData } = useFlowContext();
+  const { clientData, linkAccountStepOptions } = useOnboardingContext();
 
   const clientId = clientData?.id;
-
-  // When existing accounts present + allowMultipleAccounts, hide form until user clicks "Add account"
-  const [showAddForm, setShowAddForm] = useState(false);
-  const [prefillCertifyChecked, setPrefillCertifyChecked] = useState(false);
-
-  // ─── Data fetching ──────────────────────────────────────────────────────────
-  const { data: clientResponseData } = useSmbdoGetClient(clientId ?? '', {
-    query: { enabled: !!clientId },
-  });
 
   const { data: recipientsData, isLoading: isLoadingRecipients } =
     useGetAllRecipients(
@@ -75,127 +48,6 @@ export const LinkAccountScreen = () => {
   const shouldRedirectOnExisting =
     !!existingAccount && !linkAccountStepOptions?.allowMultipleAccounts;
 
-  // ─── Preset selection & derived state ───────────────────────────────────────
-  const {
-    presetAccounts,
-    selectedPresetId,
-    setSelectedPresetId,
-    effectivePartyId,
-    effectiveInitialValues: rawEffectiveInitialValues,
-    effectiveCompletionMode,
-  } = useLinkAccountPreset({ linkAccountStepOptions, existingAccounts });
-
-  // Enrich initial values with party name when partyId resolves to a known party
-  // and the host did not explicitly provide name fields.
-  const effectiveInitialValues = useMemo(() => {
-    if (!effectivePartyId || !clientResponseData?.parties) {
-      return rawEffectiveInitialValues;
-    }
-    const party = (
-      clientResponseData.parties as Array<Record<string, unknown>>
-    ).find((p) => p.id === effectivePartyId);
-    if (!party) return rawEffectiveInitialValues;
-
-    return enrichInitialValuesWithPartyName(rawEffectiveInitialValues, party);
-  }, [rawEffectiveInitialValues, effectivePartyId, clientResponseData]);
-
-  // ─── Acknowledgements state ─────────────────────────────────────────────────
-  const acknowledgementItems = linkAccountStepOptions?.reviewAcknowledgements;
-  const acknowledgements = useLinkAccountAcknowledgements({
-    items: acknowledgementItems,
-    resetDeps: [effectiveCompletionMode],
-  });
-
-  // ─── Form config composition ────────────────────────────────────────────────
-  const {
-    configWithOverride,
-    bankFormConfigForPrefill,
-    prefillSummaryFormData,
-    summaryDisplayedPaymentTypes,
-  } = useLinkAccountFormConfig({
-    linkAccountStepOptions,
-    effectiveCompletionMode,
-    effectiveInitialValues,
-    acknowledgementItems,
-  });
-
-  // ─── Form submission ────────────────────────────────────────────────────────
-  const {
-    submit,
-    status,
-    error: formError,
-    reset,
-  } = useRecipientForm({
-    mode: 'create',
-    recipientType: 'LINKED_ACCOUNT',
-    clientId,
-    partyId: effectivePartyId,
-    onSuccess: () => {
-      if (linkAccountStepOptions?.allowMultipleAccounts) {
-        setShowAddForm(false);
-        reset();
-        invalidateRecipientQueries(queryClient, 'LINKED_ACCOUNT');
-      } else {
-        updateSessionData({ linkAccountJustCreated: true });
-        goTo('overview', { resetHistory: true });
-      }
-    },
-  });
-
-  // ─── Effects ────────────────────────────────────────────────────────────────
-  useEffect(() => {
-    setPrefillCertifyChecked(false);
-  }, [clientId, acknowledgements.idsKey, prefillSummaryFormData]);
-
-  useEffect(() => {
-    if (!prefillSummaryFormData || effectiveCompletionMode !== 'reviewOnly') {
-      return undefined;
-    }
-    const defaultCertShown =
-      bankFormConfigForPrefill.requiredFields.certification === true;
-    const dirty =
-      Object.values(acknowledgements.checked).some(Boolean) ||
-      (defaultCertShown && prefillCertifyChecked);
-    setFlowUnsavedChanges('link-account-prefill', dirty);
-    return () => setFlowUnsavedChanges('link-account-prefill', false);
-  }, [
-    acknowledgements.checked,
-    bankFormConfigForPrefill.requiredFields.certification,
-    effectiveCompletionMode,
-    prefillCertifyChecked,
-    prefillSummaryFormData,
-    setFlowUnsavedChanges,
-  ]);
-
-  // ─── Derived config for editable BankAccountForm ────────────────────────────
-  const config = useMemo(
-    () => ({
-      ...configWithOverride,
-      content: {
-        ...configWithOverride.content,
-        submitButtonText: t('screens.linkAccount.submitButton', 'Link Account'),
-        cancelButtonText: t('common:cancel', 'Cancel'),
-      },
-      existingAccounts: linkAccountStepOptions?.allowMultipleAccounts
-        ? existingAccounts
-        : undefined,
-    }),
-    [
-      configWithOverride,
-      t,
-      linkAccountStepOptions?.allowMultipleAccounts,
-      existingAccounts,
-    ]
-  );
-
-  // ─── Handlers ───────────────────────────────────────────────────────────────
-  const handleSubmit = (data: BankAccountFormData) => submit(data);
-  const handleBack = () => {
-    reset();
-    goTo('overview', { resetHistory: true });
-  };
-
-  // ─── Render: Loading ────────────────────────────────────────────────────────
   if (isLoadingRecipients) {
     return (
       <StepLayout title={t('screens.linkAccount.title', 'Link a bank account')}>
@@ -206,7 +58,6 @@ export const LinkAccountScreen = () => {
     );
   }
 
-  // ─── Render: Redirect when single existing account ──────────────────────────
   if (shouldRedirectOnExisting) {
     setTimeout(() => goTo('overview', { resetHistory: true }), 0);
     return (
@@ -218,143 +69,15 @@ export const LinkAccountScreen = () => {
     );
   }
 
-  // ─── Shared sub-elements ────────────────────────────────────────────────────
-  const displayMode =
-    linkAccountStepOptions?.existingAccountsDisplay ?? 'detailed';
-  const showExistingSection =
-    !!linkAccountStepOptions?.allowMultipleAccounts &&
-    existingAccounts.length > 0;
-  const shouldHideForm = showExistingSection && !showAddForm;
-
-  const existingAccountsSection = showExistingSection ? (
-    <ExistingLinkedAccountsList
-      accounts={existingAccounts}
-      displayMode={displayMode}
-      hideRemoval={!!hideLinkedAccountRemoval}
-      showAddButton={!showAddForm}
-      onAddClick={() => setShowAddForm(true)}
-    />
-  ) : null;
-
-  const accountSelector =
-    presetAccounts && presetAccounts.length > 1 ? (
-      <LinkAccountPresetSelector
-        presets={presetAccounts}
-        value={selectedPresetId}
-        onChange={setSelectedPresetId}
-      />
-    ) : null;
-
-  const errorAlert = formError ? (
-    <LinkAccountErrorAlert error={formError} />
-  ) : undefined;
-
-  const acknowledgementsIntro =
-    acknowledgementItems?.length &&
-    linkAccountStepOptions?.showAcknowledgementsIntro
-      ? t(
-          'screens.linkAccount.prefillSummary.acknowledgementsIntro',
-          'By electronically linking this account, you agree that:'
-        )
-      : undefined;
-
-  // ─── Render: Existing accounts only (form hidden) ───────────────────────────
-  if (shouldHideForm) {
-    return (
-      <StepLayout
-        title={t('screens.linkAccount.title', 'Link a bank account')}
-        description={t(
-          'screens.linkAccount.multiAccount.manageDescription',
-          'Manage your linked bank accounts or add a new one.'
-        )}
-      >
-        <div className="eb-mt-6">{existingAccountsSection}</div>
-      </StepLayout>
-    );
-  }
-
-  // ─── Render: Review-only mode ───────────────────────────────────────────────
-  if (prefillSummaryFormData && effectiveCompletionMode === 'reviewOnly') {
-    return (
-      <LinkAccountPrefillSummaryView
-        title={t('screens.linkAccount.title', 'Link a bank account')}
-        description={t(
-          'screens.linkAccount.prefillSummary.description',
-          'Review your bank details and accept the agreements to link this account.'
-        )}
-        preSelector={
-          <>
-            {!showAddForm && existingAccountsSection}
-            {accountSelector}
-          </>
-        }
-        data={prefillSummaryFormData}
-        displayedPaymentTypes={summaryDisplayedPaymentTypes}
-        bankFormConfig={bankFormConfigForPrefill}
-        acknowledgements={acknowledgementItems}
-        acknowledgementsIntro={acknowledgementsIntro}
-        acknowledgementChecked={acknowledgements.checked}
-        onAcknowledgementChange={acknowledgements.handleChange}
-        acknowledgementsComplete={acknowledgements.isComplete}
-        certifyChecked={prefillCertifyChecked}
-        onCertifyCheckedChange={setPrefillCertifyChecked}
-        onSubmit={handleSubmit}
-        onCancel={handleBack}
-        isSubmitting={status === 'pending'}
-        errorAlert={errorAlert}
-        submitLabel={tString(
-          'screens.linkAccount.review.confirmButton',
-          'Confirm and link account'
-        )}
-        cancelLabel={tString('common:cancel', 'Cancel')}
-        groupAriaLabel={tString(
-          'screens.linkAccount.review.acknowledgementsGroupLabel',
-          'Agreements required to link this account'
-        )}
-        accountHolderLabel={tString(
-          'screens.linkAccount.prefillSummary.accountHolderLabel',
-          'Account holder'
-        )}
-      />
-    );
-  }
-
-  // ─── Render: Editable bank account form ─────────────────────────────────────
-  const defaultValuesOverride =
-    effectiveCompletionMode === 'editable' ? effectiveInitialValues : undefined;
-
   return (
-    <StepLayout
-      title={t('screens.linkAccount.title', 'Link a bank account')}
-      description={t(
-        'screens.linkAccount.description',
-        'Connect your bank account to receive payouts.'
-      )}
-    >
-      <div className="eb-mt-6">
-        {!showAddForm && existingAccountsSection}
-        {accountSelector}
-        <BankAccountForm
-          config={config}
-          client={clientResponseData ?? clientData}
-          defaultValuesOverride={defaultValuesOverride}
-          onSubmit={handleSubmit}
-          onCancel={handleBack}
-          isLoading={status === 'pending'}
-          showCard={false}
-          embedded
-          alert={errorAlert}
-          onDirtyChange={(dirty) =>
-            setFlowUnsavedChanges('link-account-form', dirty)
-          }
-          reviewAcknowledgements={acknowledgementItems}
-          acknowledgementsIntro={acknowledgementsIntro}
-          reviewAcknowledgementsGroupAriaLabel={tString(
-            'screens.linkAccount.review.acknowledgementsGroupLabel',
-            'Agreements required to link this account'
-          )}
-        />
-      </div>
-    </StepLayout>
+    <LinkAccountFormPanel
+      existingAccounts={existingAccounts}
+      layout="step"
+      onSuccess={() => {
+        updateSessionData({ linkAccountJustCreated: true });
+        goTo('overview', { resetHistory: true });
+      }}
+      onCancel={() => goTo('overview', { resetHistory: true })}
+    />
   );
 };

--- a/embedded-components/src/core/OnboardingFlow/screens/OverviewScreen/OverviewScreen.test.tsx
+++ b/embedded-components/src/core/OnboardingFlow/screens/OverviewScreen/OverviewScreen.test.tsx
@@ -283,7 +283,7 @@ describe('OverviewScreen', () => {
     ).not.toBeInTheDocument();
   });
 
-  test('allowMultipleAccounts shows summary CTA on overview without account card list', async () => {
+  test('allowMultipleAccounts shows linked accounts list and Add on overview', async () => {
     vi.mocked(useGetAllRecipients).mockReturnValue({
       data: {
         recipients: [
@@ -306,24 +306,18 @@ describe('OverviewScreen', () => {
 
     await waitFor(() => {
       expect(
-        screen.getByTestId('overview-manage-linked-accounts')
+        screen.getByTestId('existing-linked-accounts')
       ).toBeInTheDocument();
     });
 
+    expect(screen.getByTestId('add-another-account-btn')).toBeInTheDocument();
     expect(
-      screen.queryByTestId('existing-linked-accounts')
+      screen.queryByTestId('overview-manage-linked-accounts')
     ).not.toBeInTheDocument();
-    expect(
-      screen.getByText(
-        i18n.t(
-          'onboarding-overview:screens.overview.bankAccountSection.multiAccountOverviewDescriptionPlural',
-          { count: 2 }
-        )
-      )
-    ).toBeInTheDocument();
+    expect(screen.getByText(/Linked accounts \(2\)/i)).toBeInTheDocument();
   });
 
-  test('allowMultipleAccounts uses singular summary copy for one linked account', async () => {
+  test('allowMultipleAccounts shows singular count for one linked account', async () => {
     vi.mocked(useGetAllRecipients).mockReturnValue({
       data: { recipients: [mockOverviewLinkedRecipient] },
       isLoading: false,
@@ -340,20 +334,9 @@ describe('OverviewScreen', () => {
     });
 
     await waitFor(() => {
-      expect(
-        screen.getByTestId('overview-manage-linked-accounts')
-      ).toBeInTheDocument();
+      expect(screen.getByText(/Linked accounts \(1\)/i)).toBeInTheDocument();
     });
 
-    expect(
-      screen.queryByTestId('existing-linked-accounts')
-    ).not.toBeInTheDocument();
-    expect(
-      screen.getByText(
-        i18n.t(
-          'onboarding-overview:screens.overview.bankAccountSection.multiAccountOverviewDescriptionSingular'
-        )
-      )
-    ).toBeInTheDocument();
+    expect(screen.getByTestId('add-another-account-btn')).toBeInTheDocument();
   });
 });

--- a/embedded-components/src/core/OnboardingFlow/screens/OverviewScreen/OverviewScreen.tsx
+++ b/embedded-components/src/core/OnboardingFlow/screens/OverviewScreen/OverviewScreen.tsx
@@ -49,6 +49,8 @@ import {
   useFlowContext,
   useOnboardingContext,
 } from '@/core/OnboardingFlow/contexts';
+import { ExistingLinkedAccountsList } from '@/core/OnboardingFlow/screens/LinkAccountScreen/components/ExistingLinkedAccountsList';
+import { LinkAccountFormPanel } from '@/core/OnboardingFlow/screens/LinkAccountScreen/LinkAccountFormPanel';
 import {
   DeltaPendingFieldsPanel,
   useDeltaPendingFieldsForm,
@@ -246,59 +248,6 @@ const BusinessTypeNewSection = () => {
   );
 };
 
-/** Multi-account overview: summary + "manage linked accounts" CTA. */
-const MultiLinkedAccountsView = ({
-  linkedAccounts,
-  linkAccountEnabled,
-  successAlert,
-  lockedMessage,
-  onManage,
-}: {
-  linkedAccounts: Recipient[];
-  linkAccountEnabled: boolean;
-  successAlert: ReactNode;
-  lockedMessage: ReactNode;
-  onManage: () => void;
-}) => {
-  const { t } = useTranslationWithTokens(['onboarding-overview', 'common']);
-
-  return (
-    <>
-      {successAlert}
-      {lockedMessage}
-      <Card className="eb-rounded-md eb-border eb-bg-card eb-p-4">
-        <p className="eb-text-sm eb-text-foreground">
-          {linkedAccounts.length === 1
-            ? t(
-                'screens.overview.bankAccountSection.multiAccountOverviewDescriptionSingular',
-                'You have 1 linked account for payouts. Open the bank linking step to add another account or manage details.'
-              )
-            : t(
-                'screens.overview.bankAccountSection.multiAccountOverviewDescriptionPlural',
-                'You have {{count}} linked accounts for payouts. Open the bank linking step to add another account or manage details.',
-                { count: linkedAccounts.length }
-              )}
-        </p>
-        <div className="eb-mt-4 eb-flex eb-justify-end">
-          <Button
-            variant={linkAccountEnabled ? 'default' : 'secondary'}
-            size="sm"
-            disabled={!linkAccountEnabled}
-            data-testid="overview-manage-linked-accounts"
-            onClick={onManage}
-          >
-            {t(
-              'screens.overview.bankAccountSection.manageLinkedAccountsButton',
-              'Manage linked accounts'
-            )}
-            <ChevronRightIcon />
-          </Button>
-        </div>
-      </Card>
-    </>
-  );
-};
-
 /** Single-account overview: the linked account card with verify/details/remove actions. */
 const SingleLinkedAccountView = ({
   recipient,
@@ -391,17 +340,13 @@ const SingleLinkedAccountView = ({
   );
 };
 
-/** Not-started overview: rejected-accounts accordion + "link account" start card. */
-const NoLinkedAccountView = ({
+/** Locked empty state — no interactive form when linking is disabled. */
+const LockedEmptyLinkedAccountView = ({
   clientId,
-  linkAccountEnabled,
   lockedMessage,
-  onStart,
 }: {
   clientId?: string;
-  linkAccountEnabled: boolean;
   lockedMessage: ReactNode;
-  onStart: () => void;
 }) => {
   const { t } = useTranslationWithTokens(['onboarding-overview', 'common']);
 
@@ -412,54 +357,17 @@ const NoLinkedAccountView = ({
         queryParams={{ clientId }}
       />
       {lockedMessage}
-      <Card
-        className={cn('eb-rounded-md eb-border eb-bg-card eb-p-3', {
-          'eb-border-dashed eb-border-muted-foreground': !linkAccountEnabled,
-        })}
-      >
+      <Card className="eb-rounded-md eb-border eb-border-dashed eb-border-muted-foreground eb-bg-card eb-p-3">
         <div className="eb-flex eb-w-full eb-justify-between">
           <div className="eb-flex eb-items-center eb-gap-2">
-            <svg
-              width="12"
-              height="12"
-              viewBox="0 0 12 12"
-              fill="none"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path d="M5.5 4V3H6.5V4H5.5Z" fill="#4C5157" fillOpacity="0.4" />
-              <path
-                fillRule="evenodd"
-                clipRule="evenodd"
-                d="M6 0L12 6H10V11H12V12H0V11L2 11V6H0L6 0ZM3 6V11H4V6H3ZM5 6V11H7V6H5ZM8 6V11H9V6H8ZM6 1.41421L9.58579 5H2.41421L6 1.41421Z"
-                fill="#4C5157"
-                fillOpacity={linkAccountEnabled ? '1' : '0.8'}
-              />
-            </svg>
-            <h3
-              className={cn('eb-font-header eb-text-lg eb-font-medium', {
-                'eb-text-muted-foreground': !linkAccountEnabled,
-              })}
-            >
+            <h3 className="eb-font-header eb-text-lg eb-font-medium eb-text-muted-foreground">
               {t('screens.overview.bankAccountSection.linkAccountTitle')}
             </h3>
           </div>
-
           <div className="eb-flex [&_svg]:eb-size-4">
             <CircleDashedIcon className="eb-stroke-gray-600" />
             <span className="eb-sr-only">Not started</span>
           </div>
-        </div>
-        <div className="eb-flex eb-justify-end">
-          <Button
-            variant="secondary"
-            size="sm"
-            className="eb-mt-3"
-            disabled={!linkAccountEnabled}
-            onClick={onStart}
-          >
-            {t('common:start')}
-            <ChevronRightIcon />
-          </Button>
         </div>
       </Card>
     </div>
@@ -535,6 +443,11 @@ const LinkedBankAccountSection = () => {
     </p>
   ) : null;
 
+  const handleLinkSuccess = () => {
+    updateSessionData({ linkAccountJustCreated: true });
+    invalidateRecipientQueries(queryClient, 'LINKED_ACCOUNT');
+  };
+
   const renderContent = () => {
     if (isLoadingLinkedRecipients) {
       return (
@@ -545,24 +458,44 @@ const LinkedBankAccountSection = () => {
       );
     }
     if (linkedAccounts.length === 0) {
+      if (!linkAccountEnabled) {
+        return (
+          <LockedEmptyLinkedAccountView
+            clientId={clientData?.id}
+            lockedMessage={lockedMessage}
+          />
+        );
+      }
       return (
-        <NoLinkedAccountView
-          clientId={clientData?.id}
-          linkAccountEnabled={linkAccountEnabled}
-          lockedMessage={lockedMessage}
-          onStart={() => goTo('link-account')}
-        />
+        <div className="eb-space-y-3">
+          <RejectedAccountsAccordion
+            recipientType="LINKED_ACCOUNT"
+            queryParams={{ clientId: clientData?.id }}
+          />
+          {successAlert}
+          <LinkAccountFormPanel
+            existingAccounts={linkedAccounts}
+            layout="inline"
+            onSuccess={handleLinkSuccess}
+          />
+        </div>
       );
     }
     if (linkAccountStepOptions?.allowMultipleAccounts) {
       return (
-        <MultiLinkedAccountsView
-          linkedAccounts={linkedAccounts}
-          linkAccountEnabled={linkAccountEnabled}
-          successAlert={successAlert}
-          lockedMessage={lockedMessage}
-          onManage={() => goTo('link-account')}
-        />
+        <>
+          {successAlert}
+          {lockedMessage}
+          <ExistingLinkedAccountsList
+            accounts={linkedAccounts}
+            displayMode={
+              linkAccountStepOptions.existingAccountsDisplay ?? 'detailed'
+            }
+            hideRemoval={!!hideLinkedAccountRemoval}
+            showAddButton={linkAccountEnabled}
+            onAddClick={() => goTo('link-account')}
+          />
+        </>
       );
     }
     return (

--- a/embedded-components/src/core/OnboardingFlow/stories/Docs.mdx
+++ b/embedded-components/src/core/OnboardingFlow/stories/Docs.mdx
@@ -190,8 +190,8 @@ Linked bank account behavior appears in **two screens** (same API data, same rec
         <code>OverviewScreen</code>
       </td>
       <td>
-        Bank account section: card + <code>StatusAlert</code>.{' '}
-        <strong>Start</strong> if no linked recipient yet.{' '}
+        Bank account section: empty → inline link form; single account → card +{' '}
+        <code>StatusAlert</code>; multi → list + <strong>Add account</strong>.{' '}
         <strong>Verify Account</strong> (microdeposit dialog) when status is{' '}
         <code>READY_FOR_VALIDATION</code>.
       </td>
@@ -204,14 +204,12 @@ Linked bank account behavior appears in **two screens** (same API data, same rec
         <code>LinkAccountScreen</code>
       </td>
       <td>
-        <strong>New link:</strong> <code>BankAccountForm</code> or{' '}
-        <code>reviewOnly</code> per <code>linkAccountStepOptions</code>.{' '}
-        <strong>Multi-account:</strong> when{' '}
-        <code>allowMultipleAccounts</code> is true, existing accounts display as{' '}
-        <code>RecipientCard</code> cards (compact or detailed via{' '}
-        <code>existingAccountsDisplay</code>) with an "Add account" button.{' '}
-        Optional <code>presetAccounts</code> selector and{' '}
-        <code>partyId</code> passthrough.
+        <strong>New link / Add:</strong> <code>BankAccountForm</code> or{' '}
+        <code>reviewOnly</code> per <code>linkAccountStepOptions</code>. Opened
+        from Overview <strong>Add account</strong> when{' '}
+        <code>allowMultipleAccounts</code> is true, or via sidebar /{' '}
+        <code>flowEntry</code>. Optional <code>presetAccounts</code> selector
+        and <code>partyId</code> passthrough.
       </td>
     </tr>
   </tbody>

--- a/embedded-components/src/core/OnboardingFlow/stories/linked-account/OnboardingFlow.LinkedAccount.EnabledStatuses.story.tsx
+++ b/embedded-components/src/core/OnboardingFlow/stories/linked-account/OnboardingFlow.LinkedAccount.EnabledStatuses.story.tsx
@@ -5,8 +5,8 @@
  * statuses allow the user to initiate account linking.
  *
  * `showLinkAccountStep` controls whether the section is shown.
- * `linkAccountEnabledStatuses` controls whether the "Start" button is enabled
- * for the current client status.
+ * `linkAccountEnabledStatuses` controls whether linking is enabled
+ * for the current client status (locked empty state vs inline form).
  */
 
 import type { Meta, StoryObj } from '@storybook/react-vite';
@@ -83,7 +83,7 @@ export const ApprovedOnly: Story = {
 /**
  * **Disabled by status mismatch** — The section is shown (`showLinkAccountStep`)
  * but linking is disabled because the client is `REVIEW_IN_PROGRESS` and only
- * `APPROVED` is in the allowed list. The "Start" button is locked.
+ * `APPROVED` is in the allowed list. Linking is locked (empty locked state).
  */
 export const DisabledByStatusMismatch: Story = {
   loaders: [
@@ -111,7 +111,7 @@ export const DisabledByStatusMismatch: Story = {
 /**
  * **Multiple statuses** — Linking enabled for `APPROVED`,
  * `REVIEW_IN_PROGRESS`, and `INFORMATION_REQUESTED`. Client is in
- * `INFORMATION_REQUESTED` status so the "Start" button is active.
+ * `INFORMATION_REQUESTED` status so the inline link form is active.
  */
 export const MultipleStatuses: Story = {
   loaders: [

--- a/embedded-components/src/core/OnboardingFlow/stories/linked-account/OnboardingFlow.LinkedAccount.Interactive.story.tsx
+++ b/embedded-components/src/core/OnboardingFlow/stories/linked-account/OnboardingFlow.LinkedAccount.Interactive.story.tsx
@@ -237,41 +237,17 @@ export const _1_LinkAccount_RecipientStateMachine: Story = {
       );
     });
 
-    await step('Open Link bank account from overview card', async () => {
-      await delay(STEP_DELAY);
-      const linkHeading = await screen.findByRole('heading', {
-        name: /Link an account/i,
-      });
-      const linkCard =
-        linkHeading.closest('[class*="eb-rounded-md"]') ??
-        linkHeading.parentElement?.parentElement;
-      expect(linkCard).toBeTruthy();
-      const startLink = within(linkCard as HTMLElement).getByRole('button', {
-        name: /^Start$/i,
-      });
-      await userEvent.click(startLink);
-    });
-
-    await step('Continue to account details', async () => {
+    await step('Select account holder if multiple parties', async () => {
       await delay(STEP_DELAY * 2);
       await waitFor(
         () => {
-          const btn = Array.from(document.querySelectorAll('button')).find(
-            (b) => b.textContent?.match(/continue to account details/i)
-          );
-          if (!btn) throw new Error('Continue to account details not found');
-          return btn;
+          const el = document.querySelector(
+            'input[name="accountNumber"]'
+          ) as HTMLInputElement | null;
+          if (!el) throw new Error('Account number input not found');
         },
         { timeout: 15000 }
       );
-      const continueBtn = Array.from(document.querySelectorAll('button')).find(
-        (b) => b.textContent?.match(/continue to account details/i)
-      ) as HTMLElement;
-      await userEvent.click(continueBtn);
-    });
-
-    await step('Select account holder if multiple parties', async () => {
-      await delay(STEP_DELAY);
       const combobox = document.querySelector(
         'button[role="combobox"]'
       ) as HTMLButtonElement | null;
@@ -289,15 +265,6 @@ export const _1_LinkAccount_RecipientStateMachine: Story = {
 
     await step('Fill account number and ACH routing', async () => {
       await delay(STEP_DELAY);
-      await waitFor(
-        () => {
-          const el = document.querySelector(
-            'input[name="accountNumber"]'
-          ) as HTMLInputElement | null;
-          if (!el) throw new Error('Account number input not found');
-        },
-        { timeout: 10000 }
-      );
       const accountNumberInput = document.querySelector(
         'input[name="accountNumber"]'
       ) as HTMLInputElement;
@@ -353,24 +320,18 @@ export const _1_LinkAccount_RecipientStateMachine: Story = {
       await userEvent.click(submitBtn!);
     });
 
-    await step('Confirm link success screen', async () => {
+    await step('Confirm link success on Overview', async () => {
       await delay(STEP_DELAY * 2);
       await waitFor(
         () => {
           expect(
-            screen.getByText(/Account linked successfully/i)
+            screen.getByText(
+              /Two small deposits will be sent to your account for verification|Account linked successfully|submitted successfully/i
+            )
           ).toBeInTheDocument();
         },
         { timeout: 20000 }
       );
-    });
-
-    await step('Return to overview', async () => {
-      await delay(STEP_DELAY);
-      const back = screen.getByRole('button', {
-        name: /Return to overview/i,
-      });
-      await userEvent.click(back);
     });
 
     await step('See microdeposit pending state on overview', async () => {
@@ -379,7 +340,7 @@ export const _1_LinkAccount_RecipientStateMachine: Story = {
         () => {
           expect(
             screen.getByText(
-              /Pending Verification|Microdeposit|verification pending/i
+              /Pending Verification|Microdeposit|verification pending|Two small deposits/i
             )
           ).toBeInTheDocument();
         },
@@ -506,37 +467,22 @@ export const _2_LinkAccount_PrefillSummaryThreeAcknowledgements: Story = {
       );
     });
 
-    await step('Open Link bank account from overview card', async () => {
-      await delay(STEP_DELAY);
-      const linkHeading = await screen.findByRole('heading', {
-        name: /Link an account/i,
-      });
-      const linkCard =
-        linkHeading.closest('[class*="eb-rounded-md"]') ??
-        linkHeading.parentElement?.parentElement;
-      expect(linkCard).toBeTruthy();
-      const startLink = within(linkCard as HTMLElement).getByRole('button', {
-        name: /^Start$/i,
-      });
-      await userEvent.click(startLink);
-    });
-
-    await step('Prefill summary: disabled bank fields, no wizard', async () => {
+    await step('Prefill summary on Overview (inline, no wizard)', async () => {
       await delay(STEP_DELAY * 2);
       await waitFor(
         () => {
-          expect(
-            screen.getByRole('heading', {
-              level: 1,
-              name: /Link a bank account/i,
-            })
-          ).toBeInTheDocument();
+          expect(screen.getByText(/Taylor Morgan/i)).toBeInTheDocument();
         },
         { timeout: 15000 }
       );
-      expect(screen.getByText(/Taylor Morgan/i)).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: /Confirm and link account/i })
+      ).toBeInTheDocument();
       expect(
         screen.queryByRole('button', { name: /Continue to account details/i })
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', { name: /^Start$/i })
       ).not.toBeInTheDocument();
     });
 
@@ -584,38 +530,19 @@ export const _2_LinkAccount_PrefillSummaryThreeAcknowledgements: Story = {
       );
     });
 
-    await step('Success: account linked', async () => {
+    await step('Success: account linked on Overview', async () => {
       await delay(STEP_DELAY * 2);
       await waitFor(
         () => {
           expect(
-            screen.getByText(/Account linked successfully/i)
+            screen.getByText(
+              /Two small deposits will be sent to your account for verification|Account linked successfully|submitted successfully|Pending Verification|Microdeposit|verification pending/i
+            )
           ).toBeInTheDocument();
         },
         { timeout: 20000 }
       );
     });
-
-    await step(
-      'Return to overview — pending verification on card',
-      async () => {
-        await delay(STEP_DELAY);
-        await userEvent.click(
-          screen.getByRole('button', { name: /Return to overview/i })
-        );
-        await delay(STEP_DELAY * 2);
-        await waitFor(
-          () => {
-            expect(
-              screen.getByText(
-                /Pending Verification|Microdeposit|verification pending/i
-              )
-            ).toBeInTheDocument();
-          },
-          { timeout: 15000 }
-        );
-      }
-    );
   },
 };
 
@@ -623,7 +550,7 @@ export const _2_LinkAccount_PrefillSummaryThreeAcknowledgements: Story = {
  * **2b. Link account: editable wizard + review acknowledgements**
  *
  * Same `reviewAcknowledgements` (and optional intro) as prefill summary, but with `completionMode: 'editable'`
- * so the user completes the two-step `BankAccountForm`; agreements appear on step 2 above the certification checkbox.
+ * so the user completes the single-page `BankAccountForm`; agreements appear above submit.
  */
 export const _2b_LinkAccount_EditableWithReviewAcknowledgements: Story = {
   name: '2b. Link account: editable + review acknowledgements',
@@ -646,7 +573,7 @@ export const _2b_LinkAccount_EditableWithReviewAcknowledgements: Story = {
     docs: {
       description: {
         story:
-          "Demonstrates `reviewAcknowledgements` with `completionMode: 'editable'`: host configures the same checklist as prefill summary, but the user walks through payment methods (step 1) then account details + agreements (step 2).",
+          "Demonstrates `reviewAcknowledgements` with `completionMode: 'editable'`: host configures the same checklist as prefill summary on the single-page linked-account form.",
       },
     },
   },
@@ -684,43 +611,23 @@ export const _2b_LinkAccount_EditableWithReviewAcknowledgements: Story = {
       );
     });
 
-    await step('Open Link bank account from overview card', async () => {
-      await delay(STEP_DELAY);
-      const linkHeading = await screen.findByRole('heading', {
-        name: /Link an account/i,
-      });
-      const linkCard =
-        linkHeading.closest('[class*="eb-rounded-md"]') ??
-        linkHeading.parentElement?.parentElement;
-      expect(linkCard).toBeTruthy();
-      const startLink = within(linkCard as HTMLElement).getByRole('button', {
-        name: /^Start$/i,
-      });
-      await userEvent.click(startLink);
-    });
-
-    await step('Step 1: continue to account details', async () => {
-      await delay(STEP_DELAY * 2);
-      await waitFor(
-        () => {
-          expect(
-            screen.getByRole('heading', {
-              level: 1,
-              name: /Link a bank account/i,
-            })
-          ).toBeInTheDocument();
-        },
-        { timeout: 15000 }
-      );
-      await userEvent.click(
-        screen.getByRole('button', { name: /Continue to Account Details/i })
-      );
-    });
-
     await step(
-      'Step 2: review acknowledgements gate submit (no duplicate certification checkbox)',
+      'Single-page form: review acknowledgements gate submit',
       async () => {
         await delay(STEP_DELAY * 2);
+        await waitFor(
+          () => {
+            expect(
+              screen.getByRole('button', { name: /^Link Account$/i })
+            ).toBeInTheDocument();
+          },
+          { timeout: 15000 }
+        );
+        expect(
+          screen.queryByRole('button', {
+            name: /Continue to Account Details/i,
+          })
+        ).not.toBeInTheDocument();
         expect(
           screen.getByText(/By electronically linking this account/i)
         ).toBeInTheDocument();

--- a/embedded-components/src/core/OnboardingFlow/stories/linked-account/OnboardingFlow.LinkedAccount.MultiAccount.story.tsx
+++ b/embedded-components/src/core/OnboardingFlow/stories/linked-account/OnboardingFlow.LinkedAccount.MultiAccount.story.tsx
@@ -8,8 +8,8 @@
  *
  * Stories **1–4** use `flowEntry: { screenId: 'link-account' }` to focus on link-step
  * mechanics (`partyId`, `presetAccounts`). Stories **5–10** (`allowMultipleAccounts` and
- * existing-account seeds) omit `flowEntry` so the flow opens on **Overview** (summary +
- * **Manage linked accounts**), matching production navigation.
+ * existing-account seeds) omit `flowEntry` so the flow opens on **Overview** (list +
+ * **Add account**), matching production navigation.
  */
 
 import { efClientCorpEBMock } from '@/mocks/efClientCorpEB.mock';
@@ -229,7 +229,7 @@ export const PresetAccountsEditable: Story = {
     docs: {
       description: {
         story:
-          'Two preset accounts with a select dropdown. User picks an account, then completes the two-step bank form wizard.',
+          'Two preset accounts with a select dropdown. User picks an account, then completes the single-page bank form.',
       },
     },
   },
@@ -339,7 +339,7 @@ export const PresetAccountsThree: Story = {
  * **5. Allow multiple accounts (sequential linking)**
  *
  * Host sets `allowMultipleAccounts: true`. Opens on **Overview** (no `flowEntry`); open
- * **Manage linked accounts** (or the sidebar link step) to reach sequential linking.
+ * **Add account** (or the sidebar link step) to reach sequential linking.
  */
 export const AllowMultipleAccounts: Story = {
   name: '5. Allow multiple accounts (sequential)',
@@ -363,7 +363,7 @@ export const AllowMultipleAccounts: Story = {
     docs: {
       description: {
         story:
-          'Enables sequential linking. Starts on **Overview**; open **Manage linked accounts** to reach this step. After confirming the first account, the UI shows "Link another account" instead of redirecting to Overview. Aligned with `LinkedAccountWidget` `mode: "list"` behavior.',
+          'Enables sequential linking. Starts on **Overview** with the inline form when empty. After confirming, returns to Overview with the account list and **Add account**. Aligned with `LinkedAccountWidget` `mode: "list"` behavior.',
       },
     },
   },
@@ -407,7 +407,7 @@ export const PresetAccountsWithMultiple: Story = {
     docs: {
       description: {
         story:
-          'Full combination: three preset accounts in a selector, reviewOnly mode, and sequential linking enabled. Starts on **Overview** — open **Manage linked accounts**, then after linking one preset the user can pick the next.',
+          'Full combination: three preset accounts in a selector, reviewOnly mode, and sequential linking enabled. Starts on **Overview** with the inline form; after linking, Overview shows the list and **Add account** opens the link step for the next preset.',
       },
     },
   },
@@ -429,8 +429,8 @@ export const PresetAccountsWithMultiple: Story = {
  *
  * Shows linked accounts that already exist (returned from GET /recipients)
  * as compact display cards, with the form below to link additional accounts.
- * Demonstrates the full "manage linked accounts" view when `allowMultipleAccounts: true`.
- * No `flowEntry` — canvas starts on **Overview**, then **Manage linked accounts**.
+ * Demonstrates the full "Add account" view when `allowMultipleAccounts: true`.
+ * No `flowEntry` — canvas starts on **Overview**, then **Add account**.
  */
 export const ExistingAccountsWithAddMore: Story = {
   name: '7. Existing accounts + add more',
@@ -470,7 +470,7 @@ export const ExistingAccountsWithAddMore: Story = {
     docs: {
       description: {
         story:
-          'Starts on **Overview** with a count summary and **Manage linked accounts**. On the link step: one existing account as a compact card with an "Add account" button. Clicking the button hides existing accounts and shows the link form. Uses `allowMultipleAccounts: true`.',
+          'Starts on **Overview** with the account list and **Add account**. Add opens the link-step form. Uses `allowMultipleAccounts: true` with `existingAccountsDisplay: "compact"`.',
       },
     },
   },
@@ -533,7 +533,7 @@ export const ExistingAccountsDetailed: Story = {
     docs: {
       description: {
         story:
-          'Starts on **Overview**; open **Manage linked accounts** for the link step. Detailed view (default): one existing account with full card showing status alert, View Details, and Remove actions.',
+          'Starts on **Overview** with the account list (`existingAccountsDisplay: "detailed"`): status alert, View Details, and Remove actions. **Add account** opens the link-step form.',
       },
     },
   },
@@ -595,7 +595,7 @@ export const FreeEntryMultiAccount: Story = {
     docs: {
       description: {
         story:
-          'Starts on **Overview**; open **Manage linked accounts**. One existing account shown as a detailed card. Click "Add account" to reveal a blank editable form. User enters all bank details manually and can link multiple accounts in sequence.',
+          'Starts on **Overview** with one detailed account card. **Add account** opens a blank editable form on the link step. User enters all bank details manually and can link multiple accounts in sequence.',
       },
     },
   },
@@ -656,7 +656,7 @@ export const FreeEntryMultiAccountMultiPayment: Story = {
     docs: {
       description: {
         story:
-          'Starts on **Overview**; open **Manage linked accounts**. One existing account shown as a detailed card. Click "Add account" to reveal a blank editable form with ACH + WIRE + RTP multi-select enabled via `bankFormConfigOverride`.',
+          'Starts on **Overview** with one detailed account card. **Add account** opens a blank editable form with ACH + WIRE + RTP multi-select enabled via `bankFormConfigOverride`.',
       },
     },
   },

--- a/embedded-components/src/core/OnboardingFlow/stories/linked-account/OnboardingFlow.LinkedAccount.States.story.tsx
+++ b/embedded-components/src/core/OnboardingFlow/stories/linked-account/OnboardingFlow.LinkedAccount.States.story.tsx
@@ -75,7 +75,7 @@ function approvedLinkAccountLifecycleStory(
 /**
  * **Approved — bank link not started (no linked account yet)**
  *
- * Overview shows the dashed “Link an account” card with **Start** (no `GET /recipients` row yet). Matches the pre–linked-account state before `POST /recipients`.
+ * Overview shows the inline link form (no Start CTA; no `GET /recipients` row yet). Matches the pre–linked-account state before `POST /recipients`.
  */
 export const ApprovedWithBankLinkNotStarted: Story =
   approvedLinkAccountLifecycleStory(
@@ -180,13 +180,13 @@ export const ApprovedWithExistingLinkedAccount: Story =
 /**
  * **Approved — only rejected linked accounts (no active account)**
  *
- * The overview bank section shows the "Link an account" Start button
+ * The overview bank section shows the inline link form
  * together with a collapsible **Recently Rejected Accounts** accordion
  * listing the rejected accounts from the last 30 days.
  */
 export const ApprovedWithOnlyRejectedAccounts: Story =
   approvedLinkAccountLifecycleStory(
-    '**REJECTED only** — no active/pending account. The rejected-accounts accordion is shown alongside the Start button.',
+    '**REJECTED only** — no active/pending account. The rejected-accounts accordion is shown alongside the inline link form.',
     {
       handlerOptions: {
         existingLinkedAccounts: [

--- a/embedded-components/src/core/OnboardingFlow/stories/linked-account/README.md
+++ b/embedded-components/src/core/OnboardingFlow/stories/linked-account/README.md
@@ -4,20 +4,20 @@ Storybook: **Core → OnboardingFlow → Linked account**
 
 ## Two UI surfaces in the product (not Storybook-only)
 
-| Surface                     | File                                              | Role                                                                                                                          |
-| --------------------------- | ------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| **Overview — bank section** | `screens/OverviewScreen/OverviewScreen.tsx`       | Shows linked account **or** “Start” to open the link step. **Verify Account** when `READY_FOR_VALIDATION`.                    |
-| **Link bank account step**  | `screens/LinkAccountScreen/LinkAccountScreen.tsx` | Create flow (`editable` / `reviewOnly`), multi-account management, or redirect to Overview for single existing accounts. |
+| Surface                     | File                                              | Role                                                                                                                                    |
+| --------------------------- | ------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| **Overview — bank section** | `screens/OverviewScreen/OverviewScreen.tsx`       | Empty: inline link form. Single account: card + actions. Multi: list + **Add account**. **Verify Account** when `READY_FOR_VALIDATION`. |
+| **Link bank account step**  | `screens/LinkAccountScreen/LinkAccountScreen.tsx` | Create flow (`editable` / `reviewOnly`) for Add / sidebar deep-link; redirects to Overview for single existing accounts.                |
 
 Both surfaces use the shared **`RecipientCard`** component (from `RecipientWidgets`) for account display — the same component used by **LinkedAccountWidget**. This ensures consistent card rendering, action menus, status alerts, and microdeposit verification across all surfaces.
 
 ## Host flags: hiding Remove (no contradiction)
 
-| Goal | Prop | Where |
-| ---- | ---- | ----- |
-| Hide Remove on **Overview** linked-account row | `hideLinkedAccountRemoval` | `OnboardingFlow` |
+| Goal                                                | Prop                       | Where                                                       |
+| --------------------------------------------------- | -------------------------- | ----------------------------------------------------------- |
+| Hide Remove on **Overview** linked-account row      | `hideLinkedAccountRemoval` | `OnboardingFlow`                                            |
 | Hide Remove on **Link step** existing-account cards | `hideLinkedAccountRemoval` | `OnboardingFlow` (same prop, propagated to `RecipientCard`) |
-| Hide Remove in **widget** cards / table rows | `hideRemoveRecipient` | `LinkedAccountWidget` (via `BaseRecipientsWidget`) |
+| Hide Remove in **widget** cards / table rows        | `hideRemoveRecipient`      | `LinkedAccountWidget` (via `BaseRecipientsWidget`)          |
 
 They apply to **different surfaces**. Use **both** when your app embeds onboarding Overview **and** the
 standalone widget with the same policy.
@@ -25,16 +25,17 @@ standalone widget with the same policy.
 ## Multi-account options
 
 When `linkAccountStepOptions.allowMultipleAccounts` is `true`:
-- Existing linked accounts render as cards (using `RecipientCard`) above an "Add account" button.
+
+- **Overview** renders existing linked accounts as cards (using `RecipientCard`) with an "Add account" button that opens the link step.
 - `existingAccountsDisplay` controls card style: `'detailed'` (default) shows full cards with status alerts, Verify, View Details, Edit, and Remove; `'compact'` shows minimal cards with an overflow menu.
-- After successfully linking, a "Link another account" / "Done" prompt appears instead of auto-redirecting.
+- After successfully linking on the link step, the flow returns to Overview with the updated list.
 - `presetAccounts` can be combined with `allowMultipleAccounts` for guided sequential linking with a dropdown selector.
 
 ## Story files
 
 - **`OnboardingFlow.LinkedAccount.States.story.tsx`** — Client States: lifecycle seeds, prefill variants, existing **ACTIVE** account.
 - **`OnboardingFlow.LinkedAccount.Interactive.story.tsx`** — Play functions: full link + MSW state machine, prefill summary, **microdeposit verification from Overview** (story 3; slow pacing constants at top of play).
-- **`OnboardingFlow.LinkedAccount.MultiAccount.story.tsx`** — Multi-account features: `partyId` passthrough, `presetAccounts` selector, `allowMultipleAccounts` sequential linking, existing accounts display (compact and detailed). Stories **5–10** omit `flowEntry` so the canvas opens on **Overview** (realistic handoff via **Manage linked accounts**); stories **1–4** keep `flowEntry: 'link-account'` to isolate link-step controls.
+- **`OnboardingFlow.LinkedAccount.MultiAccount.story.tsx`** — Multi-account features: `partyId` passthrough, `presetAccounts` selector, `allowMultipleAccounts` sequential linking, existing accounts display (compact and detailed). Stories **5–10** omit `flowEntry` so the canvas opens on **Overview** (list + **Add account**); stories **1–4** keep `flowEntry: 'link-account'` to isolate link-step controls.
 
 Shared MSW helpers: **`../story-utils.tsx`** (`buildApprovedClientLinkAccountStory`, `createOnboardingFlowHandlers`, linked-account mocks).
 

--- a/embedded-components/src/core/OnboardingFlow/types/onboarding.types.ts
+++ b/embedded-components/src/core/OnboardingFlow/types/onboarding.types.ts
@@ -49,10 +49,10 @@ export type Jurisdiction = 'US' | 'CA';
 
 /**
  * Host-supplied values for the optional link-account step.
- * With `completionMode: 'editable'` (default), partial data is allowed and the user completes the two-step form.
+ * With `completionMode: 'editable'` (default), partial data is allowed and the user completes the single-page form.
  * With `completionMode: 'reviewOnly'`, supply a full {@link BankAccountFormData}-compatible payload;
  * the UI shows a read-only summary plus optional `reviewAcknowledgements`.
- * With `completionMode: 'editable'`, the same optional `reviewAcknowledgements` render on step 2 of the bank form.
+ * With `completionMode: 'editable'`, the same optional `reviewAcknowledgements` render on the single-page bank form.
  */
 export type LinkAccountInitialValues = Partial<BankAccountFormData>;
 
@@ -82,7 +82,7 @@ export type LinkAccountPresetEntry = {
 };
 
 /**
- * - **`editable`** — Full `BankAccountForm` two-step wizard; optional `initialValues` prefill. **(default)**
+ * - **`editable`** — Full single-page `BankAccountForm`; optional `initialValues` prefill. **(default)**
  * - **`reviewOnly`** — Single page via `LinkAccountPrefillSummaryView` (disabled fields + payment strip; shares config/i18n with the form, not the full form tree).
  *
  * @deprecated `'prefillSummary'` is accepted as an alias for `'reviewOnly'` for backward compatibility.
@@ -145,11 +145,9 @@ export type LinkAccountStepOptions = {
   presetAccounts?: readonly LinkAccountPresetEntry[];
   /**
    * Allow creation of multiple linked accounts sequentially.
-   * When `true`, after successfully linking an account the UI offers a
-   * "Link another account" action instead of immediately returning to Overview.
-   * The full list of linked accounts (and add flow) lives on the **link-account**
-   * step; **Overview** only shows a short count summary and **Manage linked accounts**
-   * so the list is not duplicated.
+   * When `true`, **Overview** shows the linked-account list with an **Add account**
+   * action that opens the **link-account** step form. After a successful link,
+   * the flow returns to Overview with the updated list.
    * Aligned with `LinkedAccountWidget` `mode: 'list'` behavior.
    *
    * @default false

--- a/embedded-components/src/core/RecipientWidgets/components/BankAccountForm/BankAccountForm.schema.ts
+++ b/embedded-components/src/core/RecipientWidgets/components/BankAccountForm/BankAccountForm.schema.ts
@@ -97,6 +97,9 @@ const createBaseSchema = (
           message: v('certification.validation.required'),
         })
       : z.boolean().optional(),
+
+    // Optional party id from account-holder picker (linked-account create)
+    selectedPartyId: z.string().optional(),
   });
 };
 

--- a/embedded-components/src/core/RecipientWidgets/components/BankAccountForm/BankAccountForm.tsx
+++ b/embedded-components/src/core/RecipientWidgets/components/BankAccountForm/BankAccountForm.tsx
@@ -363,6 +363,88 @@ const IndividualSelector: FC<IndividualSelectorProps> = ({
   );
 };
 
+type SelectableParty = {
+  id: string;
+  partyType: 'INDIVIDUAL' | 'ORGANIZATION';
+  label: string;
+  firstName?: string;
+  lastName?: string;
+  businessName?: string;
+  roles: string[];
+};
+
+interface PartySelectorProps {
+  control: UseFormReturn<BankAccountFormData>['control'];
+  parties: SelectableParty[];
+  selectedPartyId: string | undefined;
+  onSelect: (party: SelectableParty) => void;
+}
+
+/**
+ * Unified party picker for single-page linked-account create.
+ * Selecting a party derives accountType from partyType.
+ */
+const PartySelector: FC<PartySelectorProps> = ({
+  control,
+  parties,
+  selectedPartyId,
+  onSelect,
+}) => {
+  const { t, tString } = useTranslationWithTokens('bank-account-form');
+  const selected = parties.find((p) => p.id === selectedPartyId);
+
+  return (
+    <FormField
+      control={control}
+      name="selectedPartyId"
+      rules={{
+        required: tString('partySelector.validation.required'),
+      }}
+      render={({ fieldState }) => (
+        <FormItem>
+          <FormLabel>{t('partySelector.accountHolder')}</FormLabel>
+          <Select
+            value={selected?.id || ''}
+            onValueChange={(partyId) => {
+              const party = parties.find((p) => p.id === partyId);
+              if (party) {
+                onSelect(party);
+              }
+            }}
+          >
+            <FormControl>
+              <SelectTrigger
+                className="eb-h-auto eb-min-h-[48px]"
+                aria-invalid={fieldState.invalid || undefined}
+              >
+                <SelectValue placeholder={t('partySelector.placeholder')} />
+              </SelectTrigger>
+            </FormControl>
+            <SelectContent>
+              {parties.map((party) => (
+                <SelectItem key={party.id} value={party.id}>
+                  <div className="eb-flex eb-flex-col eb-items-start eb-gap-1 eb-py-1">
+                    <span className="eb-font-medium">{party.label}</span>
+                    <span className="eb-text-xs eb-text-muted-foreground">
+                      {party.partyType === 'INDIVIDUAL'
+                        ? t('partySelector.typeHintIndividual')
+                        : t('partySelector.typeHintOrganization')}
+                      {party.roles.length > 0
+                        ? ` · ${party.roles.map(formatRole).join(', ')}`
+                        : ''}
+                    </span>
+                  </div>
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <FormMessage />
+        </FormItem>
+      )}
+    />
+  );
+};
+
 /**
  * RoutingNumberFields - Dynamic routing number input fields per payment method
  */
@@ -695,19 +777,30 @@ interface BankAccountFormStep1Props {
   form: UseFormReturn<BankAccountFormData>;
   config: BankAccountFormProps['config'];
   effectiveConfig: BankAccountFormProps['config'];
+  /** Hide Individual/Business type control (party picker derives type). */
+  hideAccountTypeSelect?: boolean;
+  /** Hide payment method checklist when a single locked method is preselected. */
+  hidePaymentMethodSelect?: boolean;
 }
 
 const BankAccountFormStep1: FC<BankAccountFormStep1Props> = ({
   form,
   config,
   effectiveConfig,
+  hideAccountTypeSelect = false,
+  hidePaymentMethodSelect = false,
 }) => {
   const { t } = useTranslationWithTokens('bank-account-form');
+
+  if (hideAccountTypeSelect && hidePaymentMethodSelect) {
+    return null;
+  }
 
   return (
     <div className="eb-space-y-6">
       {/* Account Holder Type */}
-      {effectiveConfig.accountHolder.allowIndividual &&
+      {!hideAccountTypeSelect &&
+        effectiveConfig.accountHolder.allowIndividual &&
         effectiveConfig.accountHolder.allowOrganization && (
           <FormField
             control={form.control}
@@ -767,23 +860,25 @@ const BankAccountFormStep1: FC<BankAccountFormStep1Props> = ({
         )}
 
       {/* Payment Methods Selection */}
-      <FormField
-        control={form.control}
-        name="paymentTypes"
-        render={({ field }) => (
-          <FormItem>
-            <FormLabel>{t('paymentMethods.selectAtLeastOne')}</FormLabel>
-            <PaymentMethodSelector
-              selectedTypes={field.value}
-              onChange={field.onChange}
-              availableTypes={effectiveConfig.paymentMethods.available}
-              configs={effectiveConfig.paymentMethods.configs}
-              allowMultiple={effectiveConfig.paymentMethods.allowMultiple}
-            />
-            <FormMessage />
-          </FormItem>
-        )}
-      />
+      {!hidePaymentMethodSelect && (
+        <FormField
+          control={form.control}
+          name="paymentTypes"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>{t('paymentMethods.selectAtLeastOne')}</FormLabel>
+              <PaymentMethodSelector
+                selectedTypes={field.value}
+                onChange={field.onChange}
+                availableTypes={effectiveConfig.paymentMethods.available}
+                configs={effectiveConfig.paymentMethods.configs}
+                allowMultiple={effectiveConfig.paymentMethods.allowMultiple}
+              />
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+      )}
     </div>
   );
 };
@@ -793,6 +888,9 @@ interface BankAccountFormStep2Props {
   effectiveConfig: BankAccountFormProps['config'];
   accountType: BankAccountFormData['accountType'];
   individualParties: IndividualSelectorProps['individuals'];
+  /** When set, show unified PartySelector instead of type-branched holder fields. */
+  selectableParties?: SelectableParty[];
+  usePartySelector?: boolean;
   recipient?: Recipient;
   organizationName?: string;
   isLoading: boolean;
@@ -813,6 +911,8 @@ const BankAccountFormStep2: FC<BankAccountFormStep2Props> = ({
   effectiveConfig,
   accountType,
   individualParties,
+  selectableParties = [],
+  usePartySelector = false,
   recipient,
   organizationName,
   isLoading,
@@ -832,165 +932,207 @@ const BankAccountFormStep2: FC<BankAccountFormStep2Props> = ({
     effectiveConfig.paymentMethods.configs
   );
 
+  const handlePartySelect = (party: SelectableParty) => {
+    form.setValue('accountType', party.partyType, { shouldValidate: true });
+    form.setValue('selectedPartyId', party.id, { shouldValidate: true });
+    if (party.partyType === 'INDIVIDUAL') {
+      form.setValue('firstName', party.firstName ?? '', {
+        shouldValidate: true,
+        shouldDirty: true,
+      });
+      form.setValue('lastName', party.lastName ?? '', {
+        shouldValidate: true,
+        shouldDirty: true,
+      });
+      form.setValue('businessName', '', { shouldValidate: true });
+    } else {
+      form.setValue('businessName', party.businessName ?? '', {
+        shouldValidate: true,
+        shouldDirty: true,
+      });
+      form.setValue('firstName', '', { shouldValidate: true });
+      form.setValue('lastName', '', { shouldValidate: true });
+    }
+  };
+
   return (
     <div className="eb-space-y-4">
       {/* Account Holder Details */}
-      {accountType === 'INDIVIDUAL' ? (
-        <>
-          {effectiveConfig.accountHolder.prefillFromClient &&
-          individualParties.length > 0 &&
-          !recipient ? (
-            <>
-              <Alert noTitle variant="informative">
-                <InfoIcon className="eb-h-4 eb-w-4" />
-                <AlertDescription>
-                  {individualParties.length === 1
-                    ? t('alerts.individualOnlyAccountsSingle')
-                    : t('alerts.individualOnlyAccountsMultiple')}
-                </AlertDescription>
-              </Alert>
-              <IndividualSelector
-                control={form.control}
-                individuals={individualParties}
-                selectedFirstName={form.watch('firstName')}
-                selectedLastName={form.watch('lastName')}
-                onSelect={(individual) => {
-                  form.setValue('firstName', individual.firstName, {
-                    shouldValidate: true,
-                  });
-                  form.setValue('lastName', individual.lastName, {
-                    shouldValidate: true,
-                  });
-                  form.setValue('selectedPartyId', individual.id);
-                }}
-              />
-            </>
-          ) : (
-            <div className="eb-grid eb-grid-cols-1 eb-gap-3 md:eb-grid-cols-2">
-              <StandardFormField
-                control={form.control}
-                name="firstName"
-                type="text"
-                label={
-                  effectiveConfig.content.fieldLabels?.firstName ||
-                  t('fields.firstName.label')
-                }
-                placeholder={tString('fields.firstName.placeholder')}
-                required
-                readonly={effectiveConfig.readonlyFields?.firstName}
-                disabled={isLoading}
-                inputProps={{ autoFocus: true }}
-              />
-              <StandardFormField
-                control={form.control}
-                name="lastName"
-                type="text"
-                label={
-                  effectiveConfig.content.fieldLabels?.lastName ||
-                  t('fields.lastName.label')
-                }
-                placeholder={tString('fields.lastName.placeholder')}
-                required
-                readonly={effectiveConfig.readonlyFields?.lastName}
-                disabled={isLoading}
-              />
-            </div>
-          )}
-        </>
-      ) : (
-        <>
-          {effectiveConfig.accountHolder.prefillFromClient &&
-            organizationName &&
-            !recipient && (
-              <Alert noTitle variant="informative">
-                <InfoIcon className="eb-h-4 eb-w-4" />
-                <AlertDescription>
-                  {t('alerts.organizationOnlyAccounts')}
-                </AlertDescription>
-              </Alert>
-            )}
-          <StandardFormField
+      <fieldset className="eb-space-y-3 eb-border-0 eb-p-0">
+        <legend className="eb-mb-1 eb-text-sm eb-font-semibold">
+          {effectiveConfig.content.sections?.accountHolderInfo ||
+            t('sections.accountHolderInfo')}
+        </legend>
+        {usePartySelector && selectableParties.length > 0 && !recipient ? (
+          <PartySelector
             control={form.control}
-            name="businessName"
-            type="text"
-            label={
-              effectiveConfig.content.fieldLabels?.businessName ||
-              t('fields.businessName.label')
-            }
-            placeholder={tString('fields.businessName.placeholder')}
-            required
-            readonly={effectiveConfig.readonlyFields?.businessName}
-            disabled={isLoading}
-            inputProps={{ autoFocus: true }}
+            parties={selectableParties}
+            selectedPartyId={form.watch('selectedPartyId')}
+            onSelect={handlePartySelect}
           />
-        </>
-      )}
+        ) : accountType === 'INDIVIDUAL' ? (
+          <>
+            {effectiveConfig.accountHolder.prefillFromClient &&
+            individualParties.length > 0 &&
+            !recipient ? (
+              <>
+                <Alert noTitle variant="informative">
+                  <InfoIcon className="eb-h-4 eb-w-4" />
+                  <AlertDescription>
+                    {individualParties.length === 1
+                      ? t('alerts.individualOnlyAccountsSingle')
+                      : t('alerts.individualOnlyAccountsMultiple')}
+                  </AlertDescription>
+                </Alert>
+                <IndividualSelector
+                  control={form.control}
+                  individuals={individualParties}
+                  selectedFirstName={form.watch('firstName')}
+                  selectedLastName={form.watch('lastName')}
+                  onSelect={(individual) => {
+                    form.setValue('firstName', individual.firstName, {
+                      shouldValidate: true,
+                    });
+                    form.setValue('lastName', individual.lastName, {
+                      shouldValidate: true,
+                    });
+                    form.setValue('selectedPartyId', individual.id);
+                  }}
+                />
+              </>
+            ) : (
+              <div className="eb-grid eb-grid-cols-1 eb-gap-3 md:eb-grid-cols-2">
+                <StandardFormField
+                  control={form.control}
+                  name="firstName"
+                  type="text"
+                  label={
+                    effectiveConfig.content.fieldLabels?.firstName ||
+                    t('fields.firstName.label')
+                  }
+                  placeholder={tString('fields.firstName.placeholder')}
+                  required
+                  readonly={effectiveConfig.readonlyFields?.firstName}
+                  disabled={isLoading}
+                  inputProps={{ autoFocus: true }}
+                />
+                <StandardFormField
+                  control={form.control}
+                  name="lastName"
+                  type="text"
+                  label={
+                    effectiveConfig.content.fieldLabels?.lastName ||
+                    t('fields.lastName.label')
+                  }
+                  placeholder={tString('fields.lastName.placeholder')}
+                  required
+                  readonly={effectiveConfig.readonlyFields?.lastName}
+                  disabled={isLoading}
+                />
+              </div>
+            )}
+          </>
+        ) : (
+          <>
+            {effectiveConfig.accountHolder.prefillFromClient &&
+              organizationName &&
+              !recipient && (
+                <Alert noTitle variant="informative">
+                  <InfoIcon className="eb-h-4 eb-w-4" />
+                  <AlertDescription>
+                    {t('alerts.organizationOnlyAccounts')}
+                  </AlertDescription>
+                </Alert>
+              )}
+            <StandardFormField
+              control={form.control}
+              name="businessName"
+              type="text"
+              label={
+                effectiveConfig.content.fieldLabels?.businessName ||
+                t('fields.businessName.label')
+              }
+              placeholder={tString('fields.businessName.placeholder')}
+              required
+              readonly={effectiveConfig.readonlyFields?.businessName}
+              disabled={isLoading}
+              inputProps={{ autoFocus: true }}
+            />
+          </>
+        )}
+      </fieldset>
 
       {/* Bank Account Details */}
-      <div className="eb-grid eb-grid-cols-1 eb-gap-3 md:eb-grid-cols-2">
-        <StandardFormField
-          control={form.control}
-          name="accountNumber"
-          type="text"
-          label={
-            effectiveConfig.content.fieldLabels?.accountNumber ||
-            t('fields.accountNumber.label')
-          }
-          placeholder={tString('fields.accountNumber.placeholder')}
-          required
-          readonly={effectiveConfig.readonlyFields?.accountNumber}
-          disabled={isLoading}
-        />
-        {!effectiveConfig.internationalFieldConfig?.hideBankAccountType && (
+      <fieldset className="eb-space-y-3 eb-border-0 eb-p-0">
+        <legend className="eb-mb-1 eb-text-sm eb-font-semibold">
+          {effectiveConfig.content.sections?.bankAccountDetails ||
+            t('sections.bankAccountDetails')}
+        </legend>
+        <div className="eb-grid eb-grid-cols-1 eb-gap-3 md:eb-grid-cols-2">
           <StandardFormField
             control={form.control}
-            name="bankAccountType"
-            type="select"
+            name="accountNumber"
+            type="text"
             label={
-              effectiveConfig.content.fieldLabels?.bankAccountType ||
-              t('fields.accountType.label')
+              effectiveConfig.content.fieldLabels?.accountNumber ||
+              t('fields.accountNumber.label')
             }
-            placeholder={tString('fields.accountType.placeholder')}
+            placeholder={tString('fields.accountNumber.placeholder')}
             required
-            readonly={effectiveConfig.readonlyFields?.bankAccountType}
+            readonly={effectiveConfig.readonlyFields?.accountNumber}
             disabled={isLoading}
-            options={[
-              { value: 'CHECKING', label: t('accountTypes.checking') },
-              { value: 'SAVINGS', label: t('accountTypes.savings') },
-            ]}
           />
-        )}
-      </div>
+          {!effectiveConfig.internationalFieldConfig?.hideBankAccountType && (
+            <StandardFormField
+              control={form.control}
+              name="bankAccountType"
+              type="select"
+              label={
+                effectiveConfig.content.fieldLabels?.bankAccountType ||
+                t('fields.accountType.label')
+              }
+              placeholder={tString('fields.accountType.placeholder')}
+              required
+              readonly={effectiveConfig.readonlyFields?.bankAccountType}
+              disabled={isLoading}
+              options={[
+                { value: 'CHECKING', label: t('accountTypes.checking') },
+                { value: 'SAVINGS', label: t('accountTypes.savings') },
+              ]}
+            />
+          )}
+        </div>
 
-      {/* Routing Numbers */}
-      <RoutingNumberFields
-        control={form.control}
-        paymentMethods={paymentTypes}
-        useSameForAll={useSameRoutingNumber ?? true}
-        onUseSameForAllChange={(value) => {
-          form.setValue('useSameRoutingNumber', value);
+        {/* Routing Numbers */}
+        <RoutingNumberFields
+          control={form.control}
+          paymentMethods={paymentTypes}
+          useSameForAll={useSameRoutingNumber ?? true}
+          onUseSameForAllChange={(value) => {
+            form.setValue('useSameRoutingNumber', value);
 
-          if (value) {
-            // When switching to "same for all", use the first method's routing number
-            // and apply it to all other payment methods
-            const currentRoutingNumbers =
-              form.getValues('routingNumbers') || [];
-            const sourceRoutingNumber =
-              currentRoutingNumbers[0]?.routingNumber || '';
+            if (value) {
+              // When switching to "same for all", use the first method's routing number
+              // and apply it to all other payment methods
+              const currentRoutingNumbers =
+                form.getValues('routingNumbers') || [];
+              const sourceRoutingNumber =
+                currentRoutingNumbers[0]?.routingNumber || '';
 
-            if (sourceRoutingNumber) {
-              const updatedRoutingNumbers = paymentTypes.map((method) => ({
-                paymentType: method,
-                routingNumber: sourceRoutingNumber,
-              }));
-              form.setValue('routingNumbers', updatedRoutingNumbers);
+              if (sourceRoutingNumber) {
+                const updatedRoutingNumbers = paymentTypes.map((method) => ({
+                  paymentType: method,
+                  routingNumber: sourceRoutingNumber,
+                }));
+                form.setValue('routingNumbers', updatedRoutingNumbers);
+              }
             }
-          }
-        }}
-        configs={effectiveConfig.paymentMethods.configs}
-        disabled={isLoading}
-        internationalConfig={effectiveConfig.internationalFieldConfig}
-      />
+          }}
+          configs={effectiveConfig.paymentMethods.configs}
+          disabled={isLoading}
+          internationalConfig={effectiveConfig.internationalFieldConfig}
+        />
+      </fieldset>
 
       {/* Address Fields */}
       {showAddressFields &&
@@ -1128,7 +1270,7 @@ const BankAccountFormStep2: FC<BankAccountFormStep2Props> = ({
                       disabled={isLoading}
                     />
                   </FormControl>
-                  <FormLabel className="eb-text-sm eb-font-normal eb-text-foreground peer-disabled:eb-cursor-not-allowed peer-disabled:eb-opacity-70">
+                  <FormLabel className="peer-disabled:eb-cursor-not-allowed peer-disabled:eb-opacity-70 eb-text-sm eb-font-normal eb-text-foreground">
                     {effectiveConfig.content.certificationText}
                   </FormLabel>
                 </div>
@@ -1149,6 +1291,7 @@ interface BankAccountFormFooterProps {
   onCancel?: () => void;
   isLoading: boolean;
   skipStepOne: boolean;
+  layout: 'wizard' | 'singlePage';
   reviewAcknowledgementsComplete: boolean;
   onStep1Continue: () => void;
   onStep2Back: () => void;
@@ -1160,6 +1303,7 @@ const BankAccountFormFooter: FC<BankAccountFormFooterProps> = ({
   onCancel,
   isLoading,
   skipStepOne,
+  layout,
   reviewAcknowledgementsComplete,
   onStep1Continue,
   onStep2Back,
@@ -1176,6 +1320,44 @@ const BankAccountFormFooter: FC<BankAccountFormFooterProps> = ({
       {content.cancelButtonText || t('navigation.cancel')}
     </Button>
   ) : null;
+
+  const submitButton = (
+    <Button
+      type="submit"
+      disabled={isLoading || !reviewAcknowledgementsComplete}
+      className="eb-w-full sm:eb-w-auto sm:eb-min-w-[120px]"
+    >
+      {isLoading && (
+        <Loader2Icon className="eb-mr-2 eb-h-4 eb-w-4 eb-animate-spin" />
+      )}
+      {isLoading ? content.loadingMessage : content.submitButtonText}
+    </Button>
+  );
+
+  if (layout === 'singlePage') {
+    const singlePageButtons = (
+      <>
+        {embedded ? (
+          cancelButton
+        ) : (
+          <DialogClose asChild>{cancelButton}</DialogClose>
+        )}
+        {submitButton}
+      </>
+    );
+    if (embedded) {
+      return (
+        <div className="eb-flex eb-shrink-0 eb-flex-col-reverse eb-gap-3 eb-p-4 sm:eb-flex-row sm:eb-justify-end">
+          {singlePageButtons}
+        </div>
+      );
+    }
+    return (
+      <DialogFooter className="eb-shrink-0 eb-gap-3 eb-border-t eb-bg-muted/10 eb-p-6 eb-py-4">
+        {singlePageButtons}
+      </DialogFooter>
+    );
+  }
 
   const continueButton = (
     <Button
@@ -1205,16 +1387,7 @@ const BankAccountFormFooter: FC<BankAccountFormFooterProps> = ({
       >
         <ArrowLeftIcon /> {backLabel}
       </Button>
-      <Button
-        type="submit"
-        disabled={isLoading || !reviewAcknowledgementsComplete}
-        className="eb-w-full sm:eb-w-auto sm:eb-min-w-[120px]"
-      >
-        {isLoading && (
-          <Loader2Icon className="eb-mr-2 eb-h-4 eb-w-4 eb-animate-spin" />
-        )}
-        {isLoading ? content.loadingMessage : content.submitButtonText}
-      </Button>
+      {submitButton}
     </>
   );
 
@@ -1250,7 +1423,7 @@ const BankAccountFormFooter: FC<BankAccountFormFooterProps> = ({
 };
 
 /**
- * BankAccountForm - Core form component (2-step wizard)
+ * BankAccountForm - Core form component (2-step wizard or single-page layout)
  */
 export const BankAccountForm: FC<BankAccountFormProps> = ({
   config,
@@ -1261,6 +1434,7 @@ export const BankAccountForm: FC<BankAccountFormProps> = ({
   alert,
   client,
   skipStepOne = false,
+  layout = 'wizard',
   embedded = false,
   initialPaymentTypes: initialPaymentTypesProp,
   initialStep = 1,
@@ -1308,9 +1482,9 @@ export const BankAccountForm: FC<BankAccountFormProps> = ({
     [reviewAcknowledgements, acknowledgementChecked]
   );
 
-  // Start on step 2 if skipStepOne is true OR initialStep is 2
+  // Start on step 2 if skipStepOne is true OR initialStep is 2 (wizard only)
   const [currentStep, setCurrentStep] = useState<1 | 2>(
-    skipStepOne ? 2 : initialStep
+    layout === 'singlePage' || skipStepOne ? 2 : initialStep
   );
 
   // Extract organization name and party ID from client data if available
@@ -1352,6 +1526,67 @@ export const BankAccountForm: FC<BankAccountFormProps> = ({
         roles: party.roles || [],
       }));
   }, [client]);
+
+  /** Unified party list for single-page linked-account create (individuals + orgs). */
+  const selectableParties = useMemo((): SelectableParty[] => {
+    if (!client?.parties) return [];
+
+    const parties: SelectableParty[] = [];
+    for (const party of client.parties) {
+      if (!party.active || !party.id) continue;
+
+      if (
+        party.partyType === 'INDIVIDUAL' &&
+        config.accountHolder.allowIndividual &&
+        party.individualDetails?.firstName &&
+        party.individualDetails?.lastName
+      ) {
+        parties.push({
+          id: party.id,
+          partyType: 'INDIVIDUAL',
+          label: `${party.individualDetails.firstName} ${party.individualDetails.lastName}`,
+          firstName: party.individualDetails.firstName,
+          lastName: party.individualDetails.lastName,
+          roles: party.roles || [],
+        });
+      }
+
+      if (
+        party.partyType === 'ORGANIZATION' &&
+        config.accountHolder.allowOrganization &&
+        party.organizationDetails?.organizationName
+      ) {
+        parties.push({
+          id: party.id,
+          partyType: 'ORGANIZATION',
+          label: party.organizationDetails.organizationName,
+          businessName: party.organizationDetails.organizationName,
+          roles: party.roles || [],
+        });
+      }
+    }
+    return parties;
+  }, [
+    client,
+    config.accountHolder.allowIndividual,
+    config.accountHolder.allowOrganization,
+  ]);
+
+  const usePartySelector =
+    layout === 'singlePage' &&
+    !!config.accountHolder.prefillFromClient &&
+    selectableParties.length > 0 &&
+    !recipient;
+
+  const hidePaymentMethodSelect = useMemo(() => {
+    if (layout !== 'singlePage') return false;
+    const available = config.paymentMethods.available;
+    if (available.length !== 1) return false;
+    const only = available[0];
+    return config.paymentMethods.configs[only]?.locked === true;
+  }, [layout, config.paymentMethods]);
+
+  const hideAccountTypeSelect = usePartySelector;
 
   /** Custom `reviewAcknowledgements` replace the default certification row (avoid duplicate legal copy). */
   const configWithReviewAcknowledgements = useMemo(() => {
@@ -1595,6 +1830,28 @@ export const BankAccountForm: FC<BankAccountFormProps> = ({
     onDirtyChange?.(isDirty || acknowledgementDirty);
     return () => onDirtyChange?.(false);
   }, [isDirty, acknowledgementDirty, onDirtyChange]);
+
+  // Auto-select the only available party on single-page linked create
+  useEffect(() => {
+    if (!usePartySelector || selectableParties.length !== 1) return;
+    if (form.getValues('selectedPartyId')) return;
+    const party = selectableParties[0];
+    form.setValue('accountType', party.partyType, { shouldValidate: true });
+    form.setValue('selectedPartyId', party.id, { shouldValidate: true });
+    if (party.partyType === 'INDIVIDUAL') {
+      form.setValue('firstName', party.firstName ?? '', {
+        shouldValidate: true,
+      });
+      form.setValue('lastName', party.lastName ?? '', { shouldValidate: true });
+      form.setValue('businessName', '', { shouldValidate: true });
+    } else {
+      form.setValue('businessName', party.businessName ?? '', {
+        shouldValidate: true,
+      });
+      form.setValue('firstName', '', { shouldValidate: true });
+      form.setValue('lastName', '', { shouldValidate: true });
+    }
+  }, [usePartySelector, selectableParties, form]);
 
   const defaultValuesOverrideKey = JSON.stringify(
     defaultValuesOverride ?? null
@@ -1905,41 +2162,72 @@ export const BankAccountForm: FC<BankAccountFormProps> = ({
         >
           <div className="eb-space-y-4 eb-py-4">
             {alert}
-            {/* Step 1: Account Type & Payment Method Selection */}
-            {currentStep === 1 && (
-              <BankAccountFormStep1
-                form={form}
-                config={config}
-                effectiveConfig={effectiveConfig}
-              />
-            )}
-
-            {/* Step 2: Detailed Form */}
-            {currentStep === 2 && (
-              <BankAccountFormStep2
-                form={form}
-                effectiveConfig={effectiveConfig}
-                accountType={accountType}
-                individualParties={individualParties}
-                recipient={recipient}
-                organizationName={organizationName}
-                isLoading={isLoading}
-                paymentTypes={paymentTypes}
-                useSameRoutingNumber={useSameRoutingNumber}
-                showAddressFields={showAddressFields}
-                useStateTextField={useStateTextField}
-                requiredContactTypes={requiredContactTypes}
-                reviewAcknowledgements={reviewAcknowledgements}
-                acknowledgementChecked={acknowledgementChecked}
-                onAcknowledgementChange={handleAcknowledgementChange}
-                reviewAckGroupAriaLabel={effectiveReviewAckGroupAriaLabel}
-                acknowledgementsIntro={acknowledgementsIntro}
-              />
+            {layout === 'singlePage' ? (
+              <>
+                <BankAccountFormStep1
+                  form={form}
+                  config={config}
+                  effectiveConfig={effectiveConfig}
+                  hideAccountTypeSelect={hideAccountTypeSelect}
+                  hidePaymentMethodSelect={hidePaymentMethodSelect}
+                />
+                <BankAccountFormStep2
+                  form={form}
+                  effectiveConfig={effectiveConfig}
+                  accountType={accountType}
+                  individualParties={individualParties}
+                  selectableParties={selectableParties}
+                  usePartySelector={usePartySelector}
+                  recipient={recipient}
+                  organizationName={organizationName}
+                  isLoading={isLoading}
+                  paymentTypes={paymentTypes}
+                  useSameRoutingNumber={useSameRoutingNumber}
+                  showAddressFields={showAddressFields}
+                  useStateTextField={useStateTextField}
+                  requiredContactTypes={requiredContactTypes}
+                  reviewAcknowledgements={reviewAcknowledgements}
+                  acknowledgementChecked={acknowledgementChecked}
+                  onAcknowledgementChange={handleAcknowledgementChange}
+                  reviewAckGroupAriaLabel={effectiveReviewAckGroupAriaLabel}
+                  acknowledgementsIntro={acknowledgementsIntro}
+                />
+              </>
+            ) : (
+              <>
+                {currentStep === 1 && (
+                  <BankAccountFormStep1
+                    form={form}
+                    config={config}
+                    effectiveConfig={effectiveConfig}
+                  />
+                )}
+                {currentStep === 2 && (
+                  <BankAccountFormStep2
+                    form={form}
+                    effectiveConfig={effectiveConfig}
+                    accountType={accountType}
+                    individualParties={individualParties}
+                    recipient={recipient}
+                    organizationName={organizationName}
+                    isLoading={isLoading}
+                    paymentTypes={paymentTypes}
+                    useSameRoutingNumber={useSameRoutingNumber}
+                    showAddressFields={showAddressFields}
+                    useStateTextField={useStateTextField}
+                    requiredContactTypes={requiredContactTypes}
+                    reviewAcknowledgements={reviewAcknowledgements}
+                    acknowledgementChecked={acknowledgementChecked}
+                    onAcknowledgementChange={handleAcknowledgementChange}
+                    reviewAckGroupAriaLabel={effectiveReviewAckGroupAriaLabel}
+                    acknowledgementsIntro={acknowledgementsIntro}
+                  />
+                )}
+              </>
             )}
           </div>
         </div>
 
-        {/* Footer - Use plain div when embedded, DialogFooter when in dialog context */}
         <BankAccountFormFooter
           embedded={embedded}
           currentStep={currentStep}
@@ -1947,6 +2235,7 @@ export const BankAccountForm: FC<BankAccountFormProps> = ({
           onCancel={onCancel}
           isLoading={isLoading}
           skipStepOne={skipStepOne}
+          layout={layout}
           reviewAcknowledgementsComplete={reviewAcknowledgementsComplete}
           onStep1Continue={handleStep1Continue}
           onStep2Back={handleStep2Back}

--- a/embedded-components/src/core/RecipientWidgets/components/BankAccountForm/BankAccountForm.types.ts
+++ b/embedded-components/src/core/RecipientWidgets/components/BankAccountForm/BankAccountForm.types.ts
@@ -263,6 +263,12 @@ export interface BankAccountFormProps {
    */
   skipStepOne?: boolean;
   /**
+   * Form layout. `wizard` is the default two-step flow (recipients).
+   * `singlePage` shows holder + bank + agreements on one screen (linked-account create).
+   * @default 'wizard'
+   */
+  layout?: 'wizard' | 'singlePage';
+  /**
    * Initial step to start on (1 or 2).
    * Unlike skipStepOne, this preserves normal back button navigation.
    * Useful when returning to the form after reviewing data.

--- a/embedded-components/src/core/RecipientWidgets/components/RecipientFormDialog/RecipientFormDialog.tsx
+++ b/embedded-components/src/core/RecipientWidgets/components/RecipientFormDialog/RecipientFormDialog.tsx
@@ -281,6 +281,7 @@ export const RecipientFormDialog: FC<RecipientFormDialogProps> = ({
             onSubmit={handleSubmit}
             onCancel={handleCancel}
             isLoading={status === 'pending'}
+            layout={isCreatingLinkedAccount ? 'singlePage' : 'wizard'}
             alert={
               formError ? (
                 <FriendlyErrorAlert

--- a/embedded-components/src/core/RecipientWidgets/stories/BankAccountForm.linkedAccountPaymentMethods.story.tsx
+++ b/embedded-components/src/core/RecipientWidgets/stories/BankAccountForm.linkedAccountPaymentMethods.story.tsx
@@ -43,6 +43,7 @@ function LinkedAccountBankFormPaymentMethodsDemo({
         client={storyClient}
         config={config}
         embedded
+        layout="singlePage"
         showCard
         onSubmit={() => {}}
         onCancel={() => {}}

--- a/embedded-components/src/i18n/en-US/bank-account-form.json
+++ b/embedded-components/src/i18n/en-US/bank-account-form.json
@@ -50,6 +50,15 @@
       "required": "Please select an account holder"
     }
   },
+  "partySelector": {
+    "accountHolder": "Account Holder",
+    "placeholder": "Choose who this account belongs to",
+    "typeHintIndividual": "Individual",
+    "typeHintOrganization": "Business",
+    "validation": {
+      "required": "Please select an account holder"
+    }
+  },
   "routingNumbers": {
     "legend": "Routing Numbers",
     "useSameForAll": "Use same routing number for all payment methods",

--- a/embedded-components/src/i18n/es-US/bank-account-form.json
+++ b/embedded-components/src/i18n/es-US/bank-account-form.json
@@ -50,6 +50,15 @@
       "required": "Por favor seleccione un titular de cuenta"
     }
   },
+  "partySelector": {
+    "accountHolder": "Titular de la cuenta",
+    "placeholder": "Elija a quién pertenece esta cuenta",
+    "typeHintIndividual": "Individual",
+    "typeHintOrganization": "Empresa",
+    "validation": {
+      "required": "Por favor seleccione un titular de cuenta"
+    }
+  },
   "routingNumbers": {
     "legend": "Números de ruta",
     "useSameForAll": "Usar el mismo número de ruta para todos los métodos de pago",

--- a/embedded-components/src/i18n/fr-CA/bank-account-form.json
+++ b/embedded-components/src/i18n/fr-CA/bank-account-form.json
@@ -50,6 +50,15 @@
       "required": "Veuillez sélectionner un titulaire de compte"
     }
   },
+  "partySelector": {
+    "accountHolder": "Titulaire du compte",
+    "placeholder": "Choisissez le titulaire de ce compte",
+    "typeHintIndividual": "Particulier",
+    "typeHintOrganization": "Entreprise",
+    "validation": {
+      "required": "Veuillez sélectionner un titulaire de compte"
+    }
+  },
   "routingNumbers": {
     "legend": "Numéros d'acheminement",
     "useSameForAll": "Utiliser le même numéro d'acheminement pour toutes les méthodes de paiement",


### PR DESCRIPTION
…nd update README

- Simplified the integration test for the link-account scenario by removing unnecessary steps and comments, focusing on the single-page form functionality.
- Updated the README to clarify the `completionMode` prop for the OnboardingFlow, emphasizing the single-page form behavior.
- Enhanced the LinkAccountScreen component to support inline rendering of the link account form and improved the overall structure for better readability.